### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ This function returns a channel handle that is used for all future operations on
 
 * __request_custody__: Bundle generation parameter - if set then the bundle request custody transfer and includes a CTEB extension block.
 
-* __admin_record__: Bundle generation parameter - if set then the bundle is set as an adminstrative record.  The library handles this setting automatically for Aggregate Custody Signals that it generates; but if the user wants to create their own adminstrative record, then this attribute provides that option.
+* __admin_record__: Bundle generation parameter - if set then the bundle is set as an administrative record.  The library handles this setting automatically for Aggregate Custody Signals that it generates; but if the user wants to create their own administrative record, then this attribute provides that option.
 
 * __integrity_check__: Bundle generation parameter - if set then the bundle includes a BIB extension block.
 
@@ -524,7 +524,7 @@ Initialize an attribute structure with the library default values.  This is usef
 | BP_FLAG_ACTIVE_TABLE_WRAP      | 0x00000800 | The active table wrapped; see BP_OPT_WRAP_RESPONSE |
 | BP_FLAG_DUPLICATES             | 0x00001000 | The custody ID was already acknowledged |
 | BP_FLAG_CUSTODY_FULL           | 0x00002000 | An aggregate custody signal was generated due the number of custody ID gaps exceeded the maximum allowed |
-| BP_FLAG_UNKNOWNREC             | 0x00004000 | A bundle contained unknown adminstrative record |
+| BP_FLAG_UNKNOWNREC             | 0x00004000 | A bundle contained unknown administrative record |
 | BP_FLAG_INVALID_CIPHER_SUITEID | 0x00008000 | An invalid cipher suite ID was found in a BIB |
 | BP_FLAG_INVALID_BIB_RESULT_TYPE| 0x00010000 | An invalid result type was found in a BIB |
 | BP_FLAG_INVALID_BIB_TARGET_TYPE| 0x00020000 | An invalid target type was found in a BIB |

--- a/app/bpsend.c
+++ b/app/bpsend.c
@@ -303,8 +303,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "\n                                                                                             ");
     fprintf(stderr, "\n         ipn:BP_SEND_NODE.BP_SEND_SERVICE                                                    ");
     fprintf(stderr, "\n                                                                                             ");
-    fprintf(stderr, "\n   where BP_SEND_NODE, and BP_SEND_SERVICE are sytem environment variables                   ");
-    fprintf(stderr, "\n   optionally overriden by the --node and --service parameters.                              ");
+    fprintf(stderr, "\n   where BP_SEND_NODE, and BP_SEND_SERVICE are system environment variables                   ");
+    fprintf(stderr, "\n   optionally overridden by the --node and --service parameters.                              ");
     fprintf(stderr, "\n                                                                                             ");
     fprintf(stderr, "\n   A connection is made to the ip address and port number provided on the                    ");
     fprintf(stderr, "\n   command line, and anything read from stdin is bundled and sent to the                     ");

--- a/common/lrc.c
+++ b/common/lrc.c
@@ -296,7 +296,7 @@ int lrc_decode(uint8_t* frame_buffer, int data_size)
     /* Loop Through All Data in Page */
     while(data_index < data_size)
     {
-        /* Genereate ECC for Block */
+        /* Generate ECC for Block */
         int bytes_left = data_size - data_index;
         int bytes_to_ecc = bytes_left < LRC_BLOCK_SIZE ? bytes_left : LRC_BLOCK_SIZE;
         lrc_block_encode(&frame_buffer[data_index], &frame_buffer[ecc_index], bytes_to_ecc, ecc_code);

--- a/common/rb_tree.c
+++ b/common/rb_tree.c
@@ -568,9 +568,9 @@ BP_LOCAL_SCOPE void delete_rebalance(rb_tree_t* tree, rb_node_t* node) {
 
         /*-----------------------------------------------------------------------------------
         * DELETE_CASE_3 - If parent, its siblings and its children are black then sibling can
-        *      be recolored such that pathes through sibling have one less black node which
-        *      allows us to delete node and maintain balance in tree. Pathes through parent
-        *      however now have one fewer black node than other pathes and so we must return
+        *      be recolored such that paths through sibling have one less black node which
+        *      allows us to delete node and maintain balance in tree. Paths through parent
+        *      however now have one fewer black node than other paths and so we must return
         *      to DELETE_CASE_1 to fix parent. If nodes are not recolored as described above,
         *      this function casecades
         *      into cases 4, 5 & 6.
@@ -1161,7 +1161,7 @@ int rb_tree_create(bp_val_t max_size, rb_tree_t* tree)
  *      are simply appended to the free stack.
  *
  * tree - A ptr to an rb_tree_t to clear all of its nodes. [OUTPUT]
- * returns: A status indicating the sucess of the clear operation.
+ * returns: A status indicating the success of the clear operation.
  *--------------------------------------------------------------------------------------*/
 int rb_tree_clear(rb_tree_t* tree)
 {
@@ -1302,7 +1302,7 @@ int rb_tree_delete(bp_val_t value, rb_tree_t* tree)
                        upper_node to be populated on success. */
                     assert(upper_node != NULL);
 
-                    /* Memory was sucessfully allocated to the new node. */
+                    /* Memory was successfully allocated to the new node. */
                     upper_node->range.offset = node->range.value + node->range.offset - upper_node->range.value;
                     node->range.offset = value - node->range.value - 1;
                 }

--- a/v6/dacs.c
+++ b/v6/dacs.c
@@ -53,7 +53,7 @@ int dacs_write(uint8_t* rec, int size, int max_fills_per_dacs, rb_tree_t* tree, 
     rec[BP_ACS_REC_STATUS_INDEX] = BP_ACS_ACK_MASK;
 
     /* Write First CID and Fills */
-    int count_fills = 0; /* The number of fills that have occured so far. */
+    int count_fills = 0; /* The number of fills that have occurred so far. */
 
     /* Store the previous and next range fills. */
     rb_range_t range;

--- a/v6/v6.h
+++ b/v6/v6.h
@@ -56,7 +56,7 @@
 /* Aggregate Custody Signal Definitions */
 #define BP_ACS_REC_TYPE_INDEX           0
 #define BP_ACS_REC_STATUS_INDEX         1
-#define BP_ACS_ACK_MASK                 0x80    /* if set, then custody successfully transfered */
+#define BP_ACS_ACK_MASK                 0x80    /* if set, then custody successfully transferred */
 
 /* Processing Control Flags */
 #define BP_PCF_FRAGMENT_MASK            0x000001    /* bundle is a fragement */


### PR DESCRIPTION
Hi,

This huge PR will fix : 

- 2 typos in `README.md`
- 2 typos in `app/bpsend.c`
- 1 typo in `common/lrc.c`
- 5 typos in `common/rb_tree.c`
- 1 typo in `v6/dacs.c`
- 1 typo in `v6/v6.h`



Cheers! :robot: