### PR TITLE
Fix #73, #76, #77, initial BPv7 data types, memory pool, and codec implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(BPLIB C)
 
 option(BPLIB_INCLUDE_STORAGE "Whether or not to build the basic/example storage services as part of BPLib" ON)
 option(BPLIB_INCLUDE_BPV6 "Whether or not to the BPv6 protocol implementation as part of BPLib" ON)
+option(BPLIB_INCLUDE_BPV7 "Whether or not to the BPv7 protocol implementation as part of BPLib (EXPERIMENTAL)" OFF)
 option(BPLIB_INCLUDE_POSIX "Whether or not to the POSIX operating system abstraction as part of BPLib (standalone builds only)" ON)
 option(BPLIB_BUILD_TEST_TOOLS "Whether or not to build the test programs as part of BPLib (standalone builds only)" ON)
 
@@ -34,6 +35,7 @@ set(BPLIB_SRC
 
 # no extra link libraries at first
 set(BPLIB_LINK_LIBRARIES)
+set(BPLIB_PRIVATE_INCLUDE_DIRS common lib)
 
 # Add source units that comprise the protocol implementation
 # This is dependent on build configuration
@@ -49,6 +51,17 @@ if (BPLIB_INCLUDE_BPV6)
     v6/dacs.c
     v6/sdnv.c
   )
+  list(APPEND BPLIB_PRIVATE_INCLUDE_DIRS v6)
+
+endif()
+
+if (BPLIB_INCLUDE_BPV7)
+
+  # v7 implementation parts
+  list(APPEND BPLIB_SRC
+    v7/v7_mpool.c
+  )
+  list(APPEND BPLIB_PRIVATE_INCLUDE_DIRS v7)
 
 endif()
 
@@ -65,6 +78,7 @@ if (BPLIB_INCLUDE_STORAGE)
     store/flash_sim.c
 
   )
+  list(APPEND BPLIB_PRIVATE_INCLUDE_DIRS store)
 
 endif()
 
@@ -141,7 +155,7 @@ else()
 endif()
 
 # Internal/private header files exist within the implementation directories
-target_include_directories(bplib PRIVATE lib store common v6)
+target_include_directories(bplib PRIVATE ${BPLIB_PRIVATE_INCLUDE_DIRS})
 
 # The API to this library (which may be invoked/referenced from other apps)
 # is stored in fsw/public_inc.  Using "target_include_directories" is the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if (BPLIB_INCLUDE_BPV7)
   # v7 implementation parts
   list(APPEND BPLIB_SRC
     v7/v7_mpool.c
+    v7/v7_codec.c
   )
   list(APPEND BPLIB_PRIVATE_INCLUDE_DIRS v7)
 
@@ -112,6 +113,20 @@ else()
 
   # If using GNU GCC, then also enable full warning reporting
   target_compile_options(bplib PRIVATE $<$<C_COMPILER_ID:GNU>:-Wall -Werror -pedantic>)
+
+  if (BPLIB_INCLUDE_BPV7)
+
+    # Use pkg-config to locate tinycbor dependency (required only for v7)
+    find_package(PkgConfig)
+    pkg_search_module(TINYCBOR tinycbor)
+    message(STATUS "Found tinycbor version ${TINYCBOR_VERSION}")
+
+    list(APPEND BPLIB_LINK_LIBRARIES ${TINYCBOR_LIBRARIES})
+    list(APPEND BPLIB_PRIVATE_INCLUDE_DIRS ${TINYCBOR_INCLUDE_DIRS})
+
+  endif()
+
+
 
   # link with the requisite dependencies (this is mainly for POSIX, if using that adapter)
   target_link_libraries(bplib ${BPLIB_LINK_LIBRARIES})

--- a/v7/v7_codec.c
+++ b/v7/v7_codec.c
@@ -1,0 +1,1345 @@
+/************************************************************************
+ *
+ *  Copyright 2019 United States Government as represented by the
+ *  Administrator of the National Aeronautics and Space Administration.
+ *  All Other Rights Reserved.
+ *
+ *  This software was created at NASA's Goddard Space Flight Center.
+ *  This software is governed by the NASA Open Source Agreement and may be
+ *  used, distributed and modified only pursuant to the terms of that
+ *  agreement.
+ *
+ *************************************************************************/
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include "bplib.h"
+#include "bplib_os.h"
+
+#include "v7_types.h"
+#include "v7_codec.h"
+#include "cbor.h"
+
+typedef struct
+{
+    const bp_canonical_bundle_block_t *encode_block;
+    bp_canonical_bundle_block_t       *decode_block;
+    const void                        *content_ptr;
+    size_t                             content_size;
+    size_t                             num_fields;
+
+} v7_canonical_block_info_t;
+
+typedef struct v7_bitmap_table
+{
+    size_t       offset;
+    bp_integer_t mask;
+} v7_bitmap_table_t;
+
+typedef struct v7_encode_state
+{
+    bool           error;
+    CborEncoder   *cbor;
+    mpool_stream_t mps;
+
+} v7_encode_state_t;
+
+typedef struct v7_decode_state
+{
+    bool           error;
+    const uint8_t *base;
+    CborValue     *cbor;
+} v7_decode_state_t;
+
+static const v7_bitmap_table_t V7_BUNDLE_CONTROL_FLAGS_BITMAP_TABLE[] = {
+    {offsetof(bp_bundle_processing_control_flags_t, deletion_status_req), 0x40000},
+    {offsetof(bp_bundle_processing_control_flags_t, delivery_status_req), 0x20000},
+    {offsetof(bp_bundle_processing_control_flags_t, forwarding_status_req), 0x10000},
+    {offsetof(bp_bundle_processing_control_flags_t, reception_status_req), 0x04000},
+    {offsetof(bp_bundle_processing_control_flags_t, statusTimeRequested), 0x40},
+    {offsetof(bp_bundle_processing_control_flags_t, acknowledgementRequested), 0x20},
+    {offsetof(bp_bundle_processing_control_flags_t, mustNotFragment), 0x04},
+    {offsetof(bp_bundle_processing_control_flags_t, isAdminRecord), 0x02},
+    {offsetof(bp_bundle_processing_control_flags_t, isFragment), 0x01},
+    {0, 0} /* end of table marker, keep last */
+};
+
+static const v7_bitmap_table_t V7_BLOCK_PROCESSING_FLAGS_BITMAP_TABLE[] = {
+    {offsetof(bp_block_processing_flags_t, must_remove), 0x10},
+    {offsetof(bp_block_processing_flags_t, must_delete), 0x04},
+    {offsetof(bp_block_processing_flags_t, xmit_status), 0x02},
+    {offsetof(bp_block_processing_flags_t, must_replicate), 0x01},
+    {0, 0} /* end of table marker, keep last */
+};
+
+/*
+ * Generic encode/decode container (aka CBOR array) helpers.
+ * This handles the general process of encoding and decoding a container, specifically:
+ *  - capture the parent state
+ *  - create a new sub-state for the container
+ *  - call the function with that new state
+ *  - close out the sub-state after function returns
+ *  - resume in the parent.
+ */
+typedef void (*v7_decode_func_t)(v7_decode_state_t *dec, void *arg);
+typedef void (*v7_encode_func_t)(v7_encode_state_t *enc, const void *arg);
+
+static void v7_decode_container(v7_decode_state_t *dec, size_t entries, v7_decode_func_t func, void *arg);
+static void v7_encode_container(v7_encode_state_t *enc, size_t entries, v7_encode_func_t func, const void *arg);
+
+/*
+ * -----------------------------------------------------------------------------------
+ * Helpers for encoding/decoding of individual protocol elements
+ *
+ * Each type used in the bpv7 protocol structures should get a separate encode/decode
+ * routine here.  However these are not expected to be called externally, because one
+ * must know what structure should be occuring at this specific position in the CBOR
+ * stream.  The only externally-callable routines should operate at the block level.
+ *
+ * If a failure occurs, these set the "error" flag within the state struct.  Such
+ * an error probably means any further decoding/encoding is not possible because
+ * it may throw off the position in the CBOR stream.
+ * -----------------------------------------------------------------------------------
+ */
+
+static void v7_encode_small_int(v7_encode_state_t *enc, int val);
+static int  v7_decode_small_int(v7_decode_state_t *dec);
+
+static void v7_encode_crc(v7_encode_state_t *enc);
+static void v7_decode_crc(v7_decode_state_t *dec, bp_crcval_t *v);
+static void v7_encode_bp_integer(v7_encode_state_t *enc, const bp_integer_t *v);
+static void v7_decode_bp_integer(v7_decode_state_t *dec, bp_integer_t *v);
+static void v7_encode_bp_blocknum(v7_encode_state_t *enc, const bp_blocknum_t *v);
+static void v7_decode_bp_blocknum(v7_decode_state_t *dec, bp_blocknum_t *v);
+static void v7_encode_bp_blocktype(v7_encode_state_t *enc, const bp_blocktype_t *v);
+static void v7_decode_bp_blocktype(v7_decode_state_t *dec, bp_blocktype_t *v);
+static void v7_encode_bp_dtntime(v7_encode_state_t *enc, const bp_dtntime_t *v);
+static void v7_decode_bp_dtntime(v7_decode_state_t *dec, bp_dtntime_t *v);
+static void v7_encode_bp_sequencenumber(v7_encode_state_t *enc, const bp_sequencenumber_t *v);
+static void v7_decode_bp_sequencenumber(v7_decode_state_t *dec, bp_sequencenumber_t *v);
+static void v7_encode_bp_endpointid_scheme(v7_encode_state_t *enc, const bp_endpointid_scheme_t *v);
+static void v7_decode_bp_endpointid_scheme(v7_decode_state_t *dec, bp_endpointid_scheme_t *v);
+static void v7_encode_bp_ipn_nodenumber(v7_encode_state_t *enc, const bp_ipn_nodenumber_t *v);
+static void v7_decode_bp_ipn_nodenumber(v7_decode_state_t *dec, bp_ipn_nodenumber_t *v);
+static void v7_encode_bp_ipn_servicenumber(v7_encode_state_t *enc, const bp_ipn_servicenumber_t *v);
+static void v7_decode_bp_ipn_servicenumber(v7_decode_state_t *dec, bp_ipn_servicenumber_t *v);
+static void v7_encode_bp_ipn_uri_ssp(v7_encode_state_t *enc, const bp_ipn_uri_ssp_t *v);
+static void v7_decode_bp_ipn_uri_ssp(v7_decode_state_t *dec, bp_ipn_uri_ssp_t *v);
+static void v7_encode_bp_creation_timestamp(v7_encode_state_t *enc, const bp_creation_timestamp_t *v);
+static void v7_decode_bp_creation_timestamp(v7_decode_state_t *dec, bp_creation_timestamp_t *v);
+static void v7_encode_bp_crctype(v7_encode_state_t *enc, const bp_crctype_t *v);
+static void v7_decode_bp_crctype(v7_decode_state_t *dec, bp_crctype_t *v);
+static void v7_encode_bp_bundle_processing_control_flags(v7_encode_state_t                          *enc,
+                                                         const bp_bundle_processing_control_flags_t *v);
+static void v7_decode_bp_bundle_processing_control_flags(v7_decode_state_t                    *dec,
+                                                         bp_bundle_processing_control_flags_t *v);
+static void v7_encode_bp_block_processing_flags(v7_encode_state_t *enc, const bp_block_processing_flags_t *v);
+static void v7_decode_bp_block_processing_flags(v7_decode_state_t *dec, bp_block_processing_flags_t *v);
+static void v7_encode_bp_lifetime(v7_encode_state_t *enc, const bp_lifetime_t *v);
+static void v7_decode_bp_lifetime(v7_decode_state_t *dec, bp_lifetime_t *v);
+static void v7_encode_bp_adu_length(v7_encode_state_t *enc, const bp_adu_length_t *v);
+static void v7_decode_bp_adu_length(v7_decode_state_t *dec, bp_adu_length_t *v);
+static void v7_encode_bp_endpointid_buffer(v7_encode_state_t *enc, const bp_endpointid_buffer_t *v);
+static void v7_decode_bp_endpointid_buffer(v7_decode_state_t *dec, bp_endpointid_buffer_t *v);
+static void v7_encode_bp_primary_block(v7_encode_state_t *enc, const bp_primary_block_t *v);
+static void v7_decode_bp_primary_block(v7_decode_state_t *dec, bp_primary_block_t *v);
+static void v7_encode_bp_canonical_bundle_block(v7_encode_state_t *enc, const bp_canonical_bundle_block_t *v,
+                                                const void *content_ptr, size_t content_length);
+static void v7_decode_bp_canonical_bundle_block(v7_decode_state_t *dec, bp_canonical_bundle_block_t *v,
+                                                const void **content_ptr, size_t *content_length);
+static void v7_encode_bp_previous_node_block(v7_encode_state_t *enc, const bp_previous_node_block_t *v);
+static void v7_decode_bp_previous_node_block(v7_decode_state_t *dec, bp_previous_node_block_t *v);
+static void v7_encode_bp_bundle_age_block(v7_encode_state_t *enc, const bp_bundle_age_block_t *v);
+static void v7_decode_bp_bundle_age_block(v7_decode_state_t *dec, bp_bundle_age_block_t *v);
+static void v7_encode_bp_hop_count_block(v7_encode_state_t *enc, const bp_hop_count_block_t *v);
+static void v7_decode_bp_hop_count_block(v7_decode_state_t *dec, bp_hop_count_block_t *v);
+static void v7_encode_bp_canonical_block_buffer(v7_encode_state_t *enc, const bp_canonical_block_buffer_t *v,
+                                                const void *content_ptr, size_t content_length);
+static void v7_decode_bp_canonical_block_buffer(v7_decode_state_t *dec, bp_canonical_block_buffer_t *v,
+                                                const void **content_ptr, size_t *content_length);
+
+/*
+ * Decoding helper to save and validate/verify a complete block after decode.
+ *
+ * Initial decoding of a block will de-construct the CBOR stream into its logical elements, including the CRC,
+ * as well as determining the encoded size of the block.  Note the CLA it will only know the size of the
+ * bundle, not the blocks inside of it. In order to determine the latter, the CBOR must be decoded.  In
+ * addition to the size, the CRC type, its value, and furthermore its position in the encoded stream
+ * will also be known.
+ *
+ * Once this information is known, the block needs to be saved to the storage service.
+ *
+ * This is the best time to validate the CRC, too - because CRC can't be validated until it is found in the
+ * CBOR stream, but after decoding it is too late to check it because it needs to be zero-filled for the check.
+ * (hence a sort of circular dependency).
+ *
+ * This function will save the encoded CBOR block data to the storage service, and validate the
+ * CRC of the data in the process of doing so.
+ *
+ * Returns the actual size saved to the storage service.  If the CRC fails to validate, this returns 0,
+ * and nothing is saved to the storage service.
+ */
+static size_t v7_save_and_verify_block(mpool_t *pool, mpool_cache_block_t *head, const uint8_t *block_base,
+                                       size_t block_size, bp_crctype_t crc_type, bp_crcval_t crc_check);
+
+/*
+ * -----------------------------------------------------------------------------------
+ * IMPLEMENTATION
+ * Helpers for encoding/decoding of individual protocol elements
+ * -----------------------------------------------------------------------------------
+ */
+
+void v7_encode_small_int(v7_encode_state_t *enc, int val)
+{
+    if (!enc->error)
+    {
+        if (cbor_encode_int(enc->cbor, val) != CborNoError)
+        {
+            enc->error = true;
+        }
+    }
+}
+
+int v7_decode_small_int(v7_decode_state_t *dec)
+{
+    int val;
+
+    val = 0;
+    if (!dec->error)
+    {
+        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborIntegerType)
+        {
+            dec->error = true;
+        }
+        else
+        {
+            if (cbor_value_get_int(dec->cbor, &val) != CborNoError)
+            {
+                dec->error = true;
+            }
+            else if (cbor_value_advance_fixed(dec->cbor) != CborNoError)
+            {
+                dec->error = true;
+            }
+        }
+    }
+
+    return val;
+}
+
+void v7_encode_crc(v7_encode_state_t *enc)
+{
+    static const uint8_t    CBOR_BYTESTRING = 0x40;
+    bplib_crc_parameters_t *crc_params;
+    size_t                  crc_len;
+    size_t                  i;
+    bp_crcval_t             crc_val;
+    uint8_t                 cbor_temp_encode[1 + sizeof(crc_val)];
+    uint8_t                *pb;
+
+    /*
+     * NOTE: Unlike other encode functions, this does not accept a value passed in, as the
+     * caller would have no way of knowing it - the CRC reflects the encoded data, but this
+     * is called in the process of creating that encoded data.  So the value is pulled
+     * from the state of the stream writer.
+     *
+     * Another bit of circular dependency here:
+     *
+     * to encode the CRC requires the value, but it has to be encoded in a byte string
+     * first because the CRC includes/covers those CBOR encoding bits too.
+     *
+     * but the byte string cannot be encoded until the value is known....
+     *
+     * Note that TinyCBOR is being used in a streaming mode, thus we cannot write
+     * a string and then "back up" - it may not be possible to reverse the stream.
+     *
+     * To get around this circular dependency for now, we can predict what the CBOR
+     * encoding bytes _should_ be (always a byte string of the CRC length) and update
+     * the CRC accordingly, then actually write the CRC.
+     */
+
+    crc_params = mpool_stream_get_crc_params(&enc->mps);
+    crc_len    = bplib_crc_get_width(crc_params) / 8;
+
+    if ((1 + crc_len) > sizeof(cbor_temp_encode))
+    {
+        enc->error = true;
+    }
+    else
+    {
+        /* Predict what the enclosing CBOR octet will be */
+        cbor_temp_encode[0] = CBOR_BYTESTRING + crc_len;
+        memset(&cbor_temp_encode[1], 0, crc_len);
+
+        /* First need to inject zero bytes in place of the CRC */
+        crc_val = mpool_stream_get_intermediate_crc(&enc->mps);
+        crc_val = bplib_crc_update(crc_params, crc_val, &cbor_temp_encode, 1 + crc_len);
+        crc_val = bplib_crc_finalize(crc_params, crc_val);
+
+        /*
+         * shift out the CRC bytes, from low to high, and fill the buffer
+         * with the real crc value instead of zeros
+         */
+        pb = &cbor_temp_encode[1 + crc_len];
+        for (i = 0; i < crc_len; ++i)
+        {
+            --pb;
+            *pb = crc_val & 0xFF;
+            crc_val >>= 8;
+        }
+
+        /*
+         * Encode only the CRC bytes, NOT the bytestring major type octet,
+         * because TinyCBOR will add that on its own.
+         */
+        if (cbor_encode_byte_string(enc->cbor, pb, crc_len) != CborNoError)
+        {
+            enc->error = true;
+        }
+    }
+}
+
+void v7_decode_crc(v7_decode_state_t *dec, bp_crcval_t *v)
+{
+    bp_crcval_t crc_val;
+    uint8_t     bytes[1 + sizeof(crc_val)];
+    size_t      len;
+    size_t      i;
+
+    crc_val = 0;
+
+    if (!dec->error)
+    {
+        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborByteStringType)
+        {
+            dec->error = true;
+        }
+        else
+        {
+            len = sizeof(bytes);
+            if (cbor_value_copy_byte_string(dec->cbor, bytes, &len, NULL) != CborNoError)
+            {
+                dec->error = true;
+            }
+            else if (cbor_value_advance(dec->cbor) != CborNoError)
+            {
+                dec->error = true;
+            }
+            else
+            {
+                /* Interpret the bytestring value as an integer */
+                for (i = 0; i < len; ++i)
+                {
+                    crc_val <<= 8;
+                    crc_val |= bytes[i];
+                }
+            }
+        }
+    }
+
+    *v = crc_val;
+}
+
+void v7_encode_container(v7_encode_state_t *enc, size_t entries, v7_encode_func_t func, const void *arg)
+{
+    CborEncoder  content;
+    CborEncoder *parent;
+
+    if (!enc->error)
+    {
+        /* Save the parent encode state */
+        parent = enc->cbor;
+
+        if (cbor_encoder_create_array(parent, &content, entries) != CborNoError)
+        {
+            enc->error = true;
+        }
+        else
+        {
+            /* go into container */
+            enc->cbor = &content;
+
+            /* call the handler impl */
+            func(enc, arg);
+
+            /* return to parent */
+            if (cbor_encoder_close_container(parent, &content) != CborNoError)
+            {
+                enc->error = true;
+            }
+
+            enc->cbor = parent;
+        }
+    }
+}
+
+void v7_decode_container(v7_decode_state_t *dec, size_t entries, v7_decode_func_t func, void *arg)
+{
+    CborValue  content;
+    CborValue *parent;
+
+    if (!dec->error)
+    {
+        /* Save the parent decode state */
+        parent = dec->cbor;
+
+        if (cbor_value_at_end(parent) || cbor_value_get_type(parent) != CborArrayType)
+        {
+            dec->error = true;
+        }
+        else
+        {
+            if (cbor_value_enter_container(parent, &content) != CborNoError)
+            {
+                dec->error = true;
+            }
+            else
+            {
+                /* go into container */
+                dec->cbor = &content;
+
+                /* call the handler impl */
+                func(dec, arg);
+
+                /* This should have consumed every item */
+                if (!cbor_value_at_end(&content))
+                {
+                    dec->error = true;
+                }
+
+                /* return to parent scope */
+                if (cbor_value_leave_container(parent, &content) != CborNoError)
+                {
+                    dec->error = true;
+                }
+
+                dec->cbor = parent;
+            }
+        }
+    }
+}
+
+void v7_encode_bp_integer(v7_encode_state_t *enc, const bp_integer_t *v)
+{
+    if (!enc->error)
+    {
+        if (cbor_encode_uint(enc->cbor, *v) != CborNoError)
+        {
+            enc->error = true;
+        }
+    }
+}
+
+void v7_decode_bp_integer(v7_decode_state_t *dec, bp_integer_t *v)
+{
+    uint64_t val;
+
+    val = 0;
+    if (!dec->error)
+    {
+        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborIntegerType)
+        {
+            dec->error = true;
+        }
+        else
+        {
+            if (cbor_value_get_uint64(dec->cbor, &val) != CborNoError)
+            {
+                dec->error = true;
+            }
+            else if (cbor_value_advance_fixed(dec->cbor) != CborNoError)
+            {
+                dec->error = true;
+            }
+        }
+    }
+
+    *v = val;
+}
+
+void v7_encode_bp_blocknum(v7_encode_state_t *enc, const bp_blocknum_t *v)
+{
+    v7_encode_small_int(enc, *v);
+}
+
+void v7_decode_bp_blocknum(v7_decode_state_t *dec, bp_blocknum_t *v)
+{
+    *v = (bp_blocknum_t)v7_decode_small_int(dec);
+}
+
+void v7_encode_bp_blocktype(v7_encode_state_t *enc, const bp_blocktype_t *v)
+{
+    v7_encode_small_int(enc, *v);
+}
+
+void v7_decode_bp_blocktype(v7_decode_state_t *dec, bp_blocktype_t *v)
+{
+    *v = (bp_blocktype_t)v7_decode_small_int(dec);
+}
+
+void v7_encode_bp_dtntime(v7_encode_state_t *enc, const bp_dtntime_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_dtntime(v7_decode_state_t *dec, bp_dtntime_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+void v7_encode_bp_sequencenumber(v7_encode_state_t *enc, const bp_sequencenumber_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_sequencenumber(v7_decode_state_t *dec, bp_sequencenumber_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+void v7_encode_bp_endpointid_scheme(v7_encode_state_t *enc, const bp_endpointid_scheme_t *v)
+{
+    v7_encode_small_int(enc, *v);
+}
+
+void v7_decode_bp_endpointid_scheme(v7_decode_state_t *dec, bp_endpointid_scheme_t *v)
+{
+    *v = v7_decode_small_int(dec);
+}
+
+void v7_encode_bp_ipn_nodenumber(v7_encode_state_t *enc, const bp_ipn_nodenumber_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_ipn_nodenumber(v7_decode_state_t *dec, bp_ipn_nodenumber_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+void v7_encode_bp_ipn_servicenumber(v7_encode_state_t *enc, const bp_ipn_servicenumber_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_ipn_servicenumber(v7_decode_state_t *dec, bp_ipn_servicenumber_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+void v7_encode_bp_ipn_uri_ssp_impl(v7_encode_state_t *enc, const void *arg)
+{
+    const bp_ipn_uri_ssp_t *v = arg;
+
+    v7_encode_bp_ipn_nodenumber(enc, &v->node_number);
+    v7_encode_bp_ipn_servicenumber(enc, &v->service_number);
+}
+
+void v7_encode_bp_ipn_uri_ssp(v7_encode_state_t *enc, const bp_ipn_uri_ssp_t *v)
+{
+    v7_encode_container(enc, 2, v7_encode_bp_ipn_uri_ssp_impl, v);
+}
+
+static void v7_decode_bp_ipn_uri_ssp_impl(v7_decode_state_t *dec, void *arg)
+{
+    bp_ipn_uri_ssp_t *v = arg;
+
+    v7_decode_bp_ipn_nodenumber(dec, &v->node_number);
+    v7_decode_bp_ipn_servicenumber(dec, &v->service_number);
+}
+
+void v7_decode_bp_ipn_uri_ssp(v7_decode_state_t *dec, bp_ipn_uri_ssp_t *v)
+{
+    v7_decode_container(dec, 2, v7_decode_bp_ipn_uri_ssp_impl, v);
+}
+
+static void v7_encode_bp_creation_timestamp_impl(v7_encode_state_t *enc, const void *arg)
+{
+    const bp_creation_timestamp_t *v = arg;
+
+    v7_encode_bp_dtntime(enc, &v->time);
+    v7_encode_bp_sequencenumber(enc, &v->sequence_num);
+}
+
+void v7_encode_bp_creation_timestamp(v7_encode_state_t *enc, const bp_creation_timestamp_t *v)
+{
+    v7_encode_container(enc, 2, v7_encode_bp_creation_timestamp_impl, v);
+}
+
+static void v7_decode_bp_creation_timestamp_impl(v7_decode_state_t *dec, void *arg)
+{
+    bp_creation_timestamp_t *v = arg;
+
+    v7_decode_bp_dtntime(dec, &v->time);
+    v7_decode_bp_sequencenumber(dec, &v->sequence_num);
+}
+
+void v7_decode_bp_creation_timestamp(v7_decode_state_t *dec, bp_creation_timestamp_t *v)
+{
+    v7_decode_container(dec, 2, v7_decode_bp_creation_timestamp_impl, v);
+}
+
+void v7_encode_bp_crctype(v7_encode_state_t *enc, const bp_crctype_t *v)
+{
+    v7_encode_small_int(enc, *v);
+}
+
+void v7_decode_bp_crctype(v7_decode_state_t *dec, bp_crctype_t *v)
+{
+    *v = (bp_crctype_t)v7_decode_small_int(dec);
+}
+
+void v7_encode_bitmap(v7_encode_state_t *enc, const uint8_t *v, const v7_bitmap_table_t *ptbl)
+{
+    bp_integer_t value;
+
+    value = 0;
+    while (ptbl->mask != 0)
+    {
+        if (v[ptbl->offset])
+        {
+            value |= ptbl->mask;
+        }
+        ++ptbl;
+    }
+
+    v7_encode_bp_integer(enc, &value);
+}
+
+void v7_decode_bitmap(v7_decode_state_t *dec, uint8_t *v, const v7_bitmap_table_t *ptbl)
+{
+    bp_integer_t value;
+
+    v7_decode_bp_integer(dec, &value);
+    while (ptbl->mask != 0)
+    {
+        v[ptbl->offset] = (value & ptbl->mask) != 0;
+        ++ptbl;
+    }
+}
+
+void v7_encode_bp_bundle_processing_control_flags(v7_encode_state_t *enc, const bp_bundle_processing_control_flags_t *v)
+{
+    v7_encode_bitmap(enc, (const uint8_t *)v, V7_BUNDLE_CONTROL_FLAGS_BITMAP_TABLE);
+}
+
+void v7_decode_bp_bundle_processing_control_flags(v7_decode_state_t *dec, bp_bundle_processing_control_flags_t *v)
+{
+    v7_decode_bitmap(dec, (uint8_t *)v, V7_BUNDLE_CONTROL_FLAGS_BITMAP_TABLE);
+}
+
+void v7_encode_bp_block_processing_flags(v7_encode_state_t *enc, const bp_block_processing_flags_t *v)
+{
+    v7_encode_bitmap(enc, (const uint8_t *)v, V7_BLOCK_PROCESSING_FLAGS_BITMAP_TABLE);
+}
+
+void v7_decode_bp_block_processing_flags(v7_decode_state_t *dec, bp_block_processing_flags_t *v)
+{
+    v7_decode_bitmap(dec, (uint8_t *)v, V7_BLOCK_PROCESSING_FLAGS_BITMAP_TABLE);
+}
+
+void v7_encode_bp_lifetime(v7_encode_state_t *enc, const bp_lifetime_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_lifetime(v7_decode_state_t *dec, bp_lifetime_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+void v7_encode_bp_adu_length(v7_encode_state_t *enc, const bp_adu_length_t *v)
+{
+    v7_encode_bp_integer(enc, v);
+}
+
+void v7_decode_bp_adu_length(v7_decode_state_t *dec, bp_adu_length_t *v)
+{
+    v7_decode_bp_integer(dec, v);
+}
+
+static void v7_encode_bp_endpointid_buffer_impl(v7_encode_state_t *enc, const void *arg)
+{
+    const bp_endpointid_buffer_t *v = arg;
+
+    v7_encode_bp_endpointid_scheme(enc, &v->scheme); /* always present, indicates which other field is valid */
+
+    switch (v->scheme)
+    {
+        case bp_endpointid_scheme_ipn:
+            v7_encode_bp_ipn_uri_ssp(enc, &v->ssp.ipn);
+            break;
+
+        default:
+            /* do not know how to decode */
+            enc->error = true;
+            break;
+    }
+}
+
+void v7_encode_bp_endpointid_buffer(v7_encode_state_t *enc, const bp_endpointid_buffer_t *v)
+{
+    v7_encode_container(enc, 2, v7_encode_bp_endpointid_buffer_impl, v);
+}
+
+static void v7_decode_bp_endpointid_buffer_impl(v7_decode_state_t *dec, void *arg)
+{
+    bp_endpointid_buffer_t *v = arg;
+
+    v7_decode_bp_endpointid_scheme(dec, &v->scheme); /* always present, indicates which other field is valid */
+
+    switch (v->scheme)
+    {
+        case bp_endpointid_scheme_ipn:
+            v7_decode_bp_ipn_uri_ssp(dec, &v->ssp.ipn);
+            break;
+
+        default:
+            /* do not know how to decode */
+            dec->error = true;
+            break;
+    }
+}
+
+void v7_decode_bp_endpointid_buffer(v7_decode_state_t *dec, bp_endpointid_buffer_t *v)
+{
+    v7_decode_container(dec, 2, v7_decode_bp_endpointid_buffer_impl, v);
+}
+
+void v7_encode_bp_primary_block_impl(v7_encode_state_t *enc, const void *arg)
+{
+    const bp_primary_block_t *v = arg;
+
+    v7_encode_small_int(enc, v->version);
+    if (v->version != 7)
+    {
+        /* don't know how to encode the rest if not v7 */
+        enc->error = true;
+        return;
+    }
+
+    /* the other 7 fixed fields defined by BPv7 */
+    v7_encode_bp_bundle_processing_control_flags(enc, &v->controlFlags);
+    v7_encode_bp_crctype(enc, &v->crctype);
+    v7_encode_bp_endpointid_buffer(enc, &v->destinationEID);
+    v7_encode_bp_endpointid_buffer(enc, &v->sourceID);
+    v7_encode_bp_endpointid_buffer(enc, &v->reportEID);
+    v7_encode_bp_creation_timestamp(enc, &v->creationTimeStamp);
+    v7_encode_bp_lifetime(enc, &v->lifetime);
+
+    /* next fields depend on whether the flag is set */
+    if (v->controlFlags.isFragment)
+    {
+        v7_encode_bp_adu_length(enc, &v->fragmentOffset);
+        v7_encode_bp_adu_length(enc, &v->totalADUlength);
+    }
+
+    /* Attach the CRC if requested. */
+    if (v->crctype != bp_crctype_none)
+    {
+        v7_encode_crc(enc);
+    }
+}
+
+void v7_encode_bp_primary_block(v7_encode_state_t *enc, const bp_primary_block_t *v)
+{
+    size_t num_fields;
+
+    /*
+     * In order to encode the resulting array with a definite length (rather than CBOR
+     * indefinite length) this must predict the number of fields that will be encoded.
+     */
+    num_fields = 8; /* fixed fields per BPv7 */
+    if (v->controlFlags.isFragment)
+    {
+        num_fields += 2; /* fragments have a size + offset field */
+    }
+    if (v->crctype != bp_crctype_none)
+    {
+        ++num_fields; /* one more for CRC */
+    }
+
+    v7_encode_container(enc, num_fields, v7_encode_bp_primary_block_impl, v);
+}
+
+void v7_decode_bp_primary_block_impl(v7_decode_state_t *dec, void *arg)
+{
+    bp_primary_block_t *v = arg;
+
+    v->version = (uint8_t)v7_decode_small_int(dec);
+    if (v->version != 7)
+    {
+        /* don't know how to decode the rest if not v7 */
+        dec->error = true;
+        return;
+    }
+
+    /* the other 7 fixed fields defined by BPv7 */
+    v7_decode_bp_bundle_processing_control_flags(dec, &v->controlFlags);
+    v7_decode_bp_crctype(dec, &v->crctype);
+    v7_decode_bp_endpointid_buffer(dec, &v->destinationEID);
+    v7_decode_bp_endpointid_buffer(dec, &v->sourceID);
+    v7_decode_bp_endpointid_buffer(dec, &v->reportEID);
+    v7_decode_bp_creation_timestamp(dec, &v->creationTimeStamp);
+    v7_decode_bp_lifetime(dec, &v->lifetime);
+
+    /* next fields depend on whether the flag is set */
+    if (v->controlFlags.isFragment)
+    {
+        v7_decode_bp_adu_length(dec, &v->fragmentOffset);
+        v7_decode_bp_adu_length(dec, &v->totalADUlength);
+    }
+    else
+    {
+        v->fragmentOffset = 0;
+        v->totalADUlength = 0;
+    }
+
+    /* Attach the CRC if requested. */
+    if (v->crctype != bp_crctype_none)
+    {
+        v7_decode_crc(dec, &v->crcval);
+    }
+}
+
+void v7_decode_bp_primary_block(v7_decode_state_t *dec, bp_primary_block_t *v)
+{
+    v7_decode_container(dec, CborIndefiniteLength, v7_decode_bp_primary_block_impl, v);
+}
+
+void v7_encode_bp_previous_node_block(v7_encode_state_t *enc, const bp_previous_node_block_t *v)
+{
+    v7_encode_bp_endpointid_buffer(enc, &v->nodeId);
+}
+
+void v7_decode_bp_previous_node_block(v7_decode_state_t *dec, bp_previous_node_block_t *v)
+{
+    v7_decode_bp_endpointid_buffer(dec, &v->nodeId);
+}
+
+void v7_encode_bp_bundle_age_block(v7_encode_state_t *enc, const bp_bundle_age_block_t *v)
+{
+    v7_encode_bp_dtntime(enc, &v->age);
+}
+
+void v7_decode_bp_bundle_age_block(v7_decode_state_t *dec, bp_bundle_age_block_t *v)
+{
+    v7_decode_bp_dtntime(dec, &v->age);
+}
+
+void v7_encode_bp_hop_count_block(v7_encode_state_t *enc, const bp_hop_count_block_t *v)
+{
+    v7_encode_bp_integer(enc, &v->hopLimit);
+    v7_encode_bp_integer(enc, &v->hopCount);
+}
+
+void v7_decode_bp_hop_count_block(v7_decode_state_t *dec, bp_hop_count_block_t *v)
+{
+    v7_decode_bp_integer(dec, &v->hopLimit);
+    v7_decode_bp_integer(dec, &v->hopCount);
+}
+
+void v7_encode_bp_canonical_bundle_block(v7_encode_state_t *enc, const bp_canonical_bundle_block_t *v,
+                                         const void *content_ptr, size_t content_length)
+{
+    v7_encode_bp_blocktype(enc, &v->blockType);
+    v7_encode_bp_blocknum(enc, &v->blockNum);
+    v7_encode_bp_block_processing_flags(enc, &v->processingControlFlags);
+    v7_encode_bp_crctype(enc, &v->crctype);
+
+    /*
+     * The content is wrapped as a CBOR byte string.
+     * The data may itself be CBOR-encoded (so this may result as CBOR-in-CBOR)
+     */
+    cbor_encode_byte_string(enc->cbor, content_ptr, content_length);
+
+    /* Attach the CRC if requested. */
+    if (v->crctype != bp_crctype_none)
+    {
+        v7_encode_crc(enc);
+    }
+}
+
+void v7_decode_bp_canonical_bundle_block(v7_decode_state_t *dec, bp_canonical_bundle_block_t *v,
+                                         const void **content_ptr, size_t *content_length)
+{
+    const uint8_t *cbor_content_start_ptr;
+    size_t         cbor_content_length;
+    size_t         cbor_major_size;
+
+    v7_decode_bp_blocktype(dec, &v->blockType);
+    v7_decode_bp_blocknum(dec, &v->blockNum);
+    v7_decode_bp_block_processing_flags(dec, &v->processingControlFlags);
+    v7_decode_bp_crctype(dec, &v->crctype);
+
+    /* The block content should be encoded as a byte string, which internally may
+     * contain more CBOR encoding, but that will be done as a separate decode.
+     * For now just grab the pointers. */
+    cbor_content_start_ptr = NULL;
+    cbor_content_length    = 0;
+    if (!dec->error)
+    {
+        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborByteStringType)
+        {
+            dec->error = true;
+        }
+        else
+        {
+            cbor_content_start_ptr = cbor_value_get_next_byte(dec->cbor);
+            if (cbor_value_advance(dec->cbor) != CborNoError)
+            {
+                dec->error = true;
+            }
+
+            /*
+             * This calculated length reflects the start of this CBOR value to the
+             * start of the next CBOR value.  Notably this includes the CBOR overhead/markup
+             * for this value, which will need to be removed.  TinyCBOR will want to
+             * copy the value, so we go around it for this value and decode the major
+             * type locally.
+             */
+            cbor_content_length = cbor_value_get_next_byte(dec->cbor) - cbor_content_start_ptr;
+
+            /* Advance the pointer according to the CBOR length to get to the real data. */
+            cbor_major_size = *cbor_content_start_ptr & 0x1F;
+            if (cbor_major_size < 24)
+            {
+                /* no extra bytes beyond the major type */
+                cbor_major_size = 0;
+            }
+            else if (cbor_major_size < 28)
+            {
+                /* 1, 2, 4, or 8 additional bytes beyond the major type */
+                cbor_major_size = 1 << (cbor_major_size - 24);
+            }
+            else
+            {
+                /* Value not well formed, or indefinite length (not supported here) */
+                cbor_major_size = cbor_content_length;
+            }
+
+            ++cbor_major_size; /* Account for the CBOR major type octet itself (always there) */
+            if (cbor_major_size <= cbor_content_length)
+            {
+                cbor_content_start_ptr += cbor_major_size;
+                cbor_content_length -= cbor_major_size;
+            }
+            else
+            {
+                cbor_content_start_ptr = NULL;
+                cbor_content_length    = 0;
+            }
+        }
+    }
+
+    /* Export the pointer and length of the content part (may be NULL/0) */
+    *content_ptr    = cbor_content_start_ptr;
+    *content_length = cbor_content_length;
+
+    if (v->crctype != bp_crctype_none)
+    {
+        v7_decode_crc(dec, &v->crcval);
+    }
+}
+
+static void v7_encode_bp_canonical_block_buffer_impl(v7_encode_state_t *enc, const void *arg)
+{
+    const v7_canonical_block_info_t *info = arg;
+    v7_encode_bp_canonical_bundle_block(enc, info->encode_block, info->content_ptr, info->content_size);
+}
+
+void v7_encode_bp_canonical_block_buffer(v7_encode_state_t *enc, const bp_canonical_block_buffer_t *v,
+                                         const void *content_ptr, size_t content_length)
+{
+    v7_canonical_block_info_t info;
+
+    memset(&info, 0, sizeof(info));
+
+    /* this also needs to predict the number of fields */
+    info.num_fields = 5; /* fixed/required fields */
+    if (v->canonical_block.crctype != bp_crctype_none)
+    {
+        ++info.num_fields; /* one more for CRC */
+    }
+
+    info.encode_block = &v->canonical_block;
+    info.content_ptr  = content_ptr;
+    info.content_size = content_length;
+
+    v7_encode_container(enc, info.num_fields, v7_encode_bp_canonical_block_buffer_impl, &info);
+}
+
+static void v7_decode_bp_canonical_block_buffer_impl(v7_decode_state_t *dec, void *arg)
+{
+    v7_canonical_block_info_t *info = arg;
+    v7_decode_bp_canonical_bundle_block(dec, info->decode_block, &info->content_ptr, &info->content_size);
+}
+
+void v7_decode_bp_canonical_block_buffer(v7_decode_state_t *dec, bp_canonical_block_buffer_t *v,
+                                         const void **content_ptr, size_t *content_length)
+{
+    v7_canonical_block_info_t info;
+
+    memset(&info, 0, sizeof(info));
+
+    info.decode_block = &v->canonical_block;
+
+    v7_decode_container(dec, CborIndefiniteLength, v7_decode_bp_canonical_block_buffer_impl, &info);
+
+    *content_ptr    = info.content_ptr;
+    *content_length = info.content_size;
+}
+
+static CborError v7_encoder_write(void *arg, const void *ptr, size_t sz, CborEncoderAppendType at)
+{
+    v7_encode_state_t *v7_state = arg;
+    if (mpool_stream_write(&v7_state->mps, ptr, sz) < sz)
+    {
+        return CborErrorOutOfMemory;
+    }
+
+    return CborNoError;
+}
+
+size_t v7_save_and_verify_block(mpool_t *pool, mpool_cache_block_t *head, const uint8_t *block_base, size_t block_size,
+                                bp_crctype_t crc_type, bp_crcval_t crc_check)
+{
+    static const uint8_t    ZERO_BYTES[4] = {0};
+    size_t                  data_len;
+    size_t                  crc_len;
+    bplib_crc_parameters_t *crc_params;
+    bp_crcval_t             crc_val;
+    mpool_stream_t          mps;
+    size_t                  result;
+
+    result = 0;
+    mpool_start_stream_init(&mps, pool, mpool_stream_dir_write, crc_type);
+    crc_params = mpool_stream_get_crc_params(&mps);
+    crc_len    = bplib_crc_get_width(crc_params) / 8;
+    if (crc_len < block_size && crc_len <= sizeof(ZERO_BYTES))
+    {
+        data_len = block_size - crc_len;
+        /* first copy only the data part */
+        if (mpool_stream_write(&mps, block_base, data_len) == data_len)
+        {
+            /* snapshot the CRC intermediate value now */
+            crc_val = mpool_stream_get_intermediate_crc(&mps);
+
+            /* now copy the original (still unverified) CRC to the buffer */
+            if (mpool_stream_write(&mps, block_base + data_len, crc_len) == crc_len)
+            {
+                /* now verify the CRC - need to pump in zero bytes for CRC width */
+                crc_val = bplib_crc_update(crc_params, crc_val, ZERO_BYTES, crc_len);
+                crc_val = bplib_crc_finalize(crc_params, crc_val);
+
+                if (crc_val == crc_check)
+                {
+                    result = mpool_stream_tell(&mps);
+                    mpool_stream_attach(&mps, head);
+                }
+            }
+        }
+    }
+
+    mpool_stream_close(&mps);
+
+    return result;
+}
+
+int v7_block_decode_pri(mpool_t *pool, mpool_cache_primary_block_t *cpb, const void *data_ptr, size_t data_size)
+{
+    v7_decode_state_t   v7_state;
+    CborValue           origin;
+    bp_primary_block_t *pri;
+    size_t              block_size;
+    CborParser          parser;
+    int                 result;
+
+    pri = mpool_get_pri_block_logical(cpb);
+    memset(&v7_state, 0, sizeof(v7_state));
+
+    if (cbor_parser_init(data_ptr, data_size, 0, &parser, &origin) != CborNoError)
+    {
+        v7_state.error = true;
+    }
+    else
+    {
+        v7_state.base = data_ptr;
+        v7_state.cbor = &origin;
+
+        v7_decode_bp_primary_block(&v7_state, pri);
+    }
+
+    if (v7_state.error)
+    {
+        result = -1;
+    }
+    else
+    {
+        block_size = cbor_value_get_next_byte(&origin) - v7_state.base;
+        block_size = v7_save_and_verify_block(pool, mpool_get_pri_block_encoded_chunks(cpb), v7_state.base, block_size,
+                                              pri->crctype, pri->crcval);
+
+        if (block_size > 0)
+        {
+            result = block_size;
+        }
+        else
+        {
+            result = -1;
+        }
+    }
+
+    return result;
+}
+
+int v7_block_decode_canonical(mpool_t *pool, mpool_cache_canonical_block_t *ccb, const void *data_ptr, size_t data_size)
+{
+    v7_decode_state_t            v7_state;
+    CborValue                    origin;
+    bp_canonical_block_buffer_t *logical;
+    size_t                       block_size;
+    CborParser                   parser;
+    const void                  *content_ptr;
+    size_t                       content_offset;
+    size_t                       content_size;
+    int                          result;
+
+    logical = mpool_get_canonical_block_logical(ccb);
+    memset(&v7_state, 0, sizeof(v7_state));
+
+    if (cbor_parser_init(data_ptr, data_size, 0, &parser, &origin) != CborNoError)
+    {
+        v7_state.error = true;
+    }
+    else
+    {
+        v7_state.base = data_ptr;
+        v7_state.cbor = &origin;
+
+        v7_decode_bp_canonical_block_buffer(&v7_state, logical, &content_ptr, &content_size);
+    }
+
+    if (v7_state.error)
+    {
+        result = -1;
+    }
+    else
+    {
+        content_offset = (const uint8_t *)content_ptr - v7_state.base;
+        block_size     = cbor_value_get_next_byte(&origin) - v7_state.base;
+        block_size =
+            v7_save_and_verify_block(pool, mpool_get_canonical_block_encoded_chunks(ccb), v7_state.base, block_size,
+                                     logical->canonical_block.crctype, logical->canonical_block.crcval);
+
+        if (block_size > 0)
+        {
+            mpool_set_canonical_block_encoded_content_detail(ccb, content_offset, content_size);
+            result = block_size;
+
+            /*
+             * Second stage decode - for recognized non-payload extension blocks
+             */
+            if (cbor_parser_init(v7_state.base + content_offset, content_size, 0, &parser, &origin) != CborNoError)
+            {
+                v7_state.error = true;
+            }
+            else
+            {
+                v7_state.base += content_offset;
+                v7_state.cbor = &origin;
+
+                switch (logical->canonical_block.blockType)
+                {
+                    case bp_blocktype_payloadBlock:
+                        break;
+                    case bp_blocktype_bundleAuthenicationBlock:
+                        break;
+                    case bp_blocktype_payloadIntegrityBlock:
+                        break;
+                    case bp_blocktype_payloadConfidentialityBlock:
+                        break;
+                    case bp_blocktype_previousHopInsertionBlock:
+                        break;
+                    case bp_blocktype_previousNode:
+                        v7_decode_bp_previous_node_block(&v7_state, &logical->data.previous_node_block);
+                        break;
+                    case bp_blocktype_bundleAge:
+                        v7_decode_bp_bundle_age_block(&v7_state, &logical->data.age_block);
+                        break;
+                    case bp_blocktype_metadataExtensionBlock:
+                        break;
+                    case bp_blocktype_extensionSecurityBlock:
+                        break;
+                    case bp_blocktype_hopCount:
+                        v7_decode_bp_hop_count_block(&v7_state, &logical->data.hop_count_block);
+                        break;
+                    default:
+                        /* do nothing */
+                        break;
+                }
+            }
+
+            /* if second stage decode didn't work, then flag the whole block as bad */
+            if (v7_state.error)
+            {
+                result = -1;
+            }
+        }
+        else
+        {
+            result = -1;
+        }
+    }
+
+    return result;
+}
+
+int v7_block_encode_pri(mpool_t *pool, mpool_cache_primary_block_t *cpb)
+{
+    v7_encode_state_t         v7_state;
+    CborEncoder               origin;
+    const bp_primary_block_t *pri;
+    int                       result;
+
+    pri = mpool_get_pri_block_logical(cpb);
+    memset(&v7_state, 0, sizeof(v7_state));
+
+    mpool_start_stream_init(&v7_state.mps, pool, mpool_stream_dir_write, pri->crctype);
+    cbor_encoder_init_writer(&origin, v7_encoder_write, &v7_state);
+    v7_state.cbor = &origin;
+
+    v7_encode_bp_primary_block(&v7_state, pri);
+
+    if (!v7_state.error)
+    {
+        result = mpool_stream_tell(&v7_state.mps);
+        mpool_stream_attach(&v7_state.mps, mpool_get_pri_block_encoded_chunks(cpb));
+    }
+    else
+    {
+        result = -1;
+    }
+
+    mpool_stream_close(&v7_state.mps);
+    return result;
+}
+
+int v7_block_encode_pay(mpool_t *pool, mpool_cache_canonical_block_t *ccb, const void *data_ptr, size_t data_size)
+{
+    v7_encode_state_t                  v7_state;
+    CborEncoder                        origin;
+    const bp_canonical_block_buffer_t *pay;
+    int                                result;
+
+    pay = mpool_get_canonical_block_logical(ccb);
+    memset(&v7_state, 0, sizeof(v7_state));
+    mpool_start_stream_init(&v7_state.mps, pool, mpool_stream_dir_write, pay->canonical_block.crctype);
+    cbor_encoder_init_writer(&origin, v7_encoder_write, &v7_state);
+    v7_state.cbor = &origin;
+
+    v7_encode_bp_canonical_block_buffer(&v7_state, pay, data_ptr, data_size);
+
+    if (!v7_state.error)
+    {
+        result = mpool_stream_tell(&v7_state.mps);
+        mpool_stream_attach(&v7_state.mps, mpool_get_canonical_block_encoded_chunks(ccb));
+    }
+    else
+    {
+        result = -1;
+    }
+
+    mpool_stream_close(&v7_state.mps);
+    return result;
+}
+
+int v7_block_encode_canonical(mpool_t *pool, mpool_cache_canonical_block_t *ccb)
+{
+    v7_encode_state_t                  v7_state;
+    CborEncoder                        origin;
+    const bp_canonical_block_buffer_t *logical;
+    int                                result;
+    uint8_t                            scratch_area[128];
+    size_t                             scratch_size;
+
+    /*
+     * Encoding of a V7 extension block is a two-part affair, it must
+     * first encode the block-specific information into CBOR, then wrap
+     * those encoded octets as a CBOR byte string within the extension block.
+     * This effectively makes it CBOR-in-CBOR.
+     */
+    logical = mpool_get_canonical_block_logical(ccb);
+
+    memset(&v7_state, 0, sizeof(v7_state));
+    mpool_start_stream_init(&v7_state.mps, pool, mpool_stream_dir_write, logical->canonical_block.crctype);
+    cbor_encoder_init(&origin, scratch_area, sizeof(scratch_area), 0);
+
+    v7_state.cbor = &origin;
+
+    switch (logical->canonical_block.blockType)
+    {
+        case bp_blocktype_payloadBlock:
+            break;
+        case bp_blocktype_bundleAuthenicationBlock:
+            break;
+        case bp_blocktype_payloadIntegrityBlock:
+            break;
+        case bp_blocktype_payloadConfidentialityBlock:
+            break;
+        case bp_blocktype_previousHopInsertionBlock:
+            break;
+        case bp_blocktype_previousNode:
+            v7_encode_bp_previous_node_block(&v7_state, &logical->data.previous_node_block);
+            break;
+        case bp_blocktype_bundleAge:
+            v7_encode_bp_bundle_age_block(&v7_state, &logical->data.age_block);
+            break;
+        case bp_blocktype_metadataExtensionBlock:
+            break;
+        case bp_blocktype_extensionSecurityBlock:
+            break;
+        case bp_blocktype_hopCount:
+            v7_encode_bp_hop_count_block(&v7_state, &logical->data.hop_count_block);
+            break;
+        default:
+            /* do nothing */
+            break;
+    }
+
+    if (!v7_state.error)
+    {
+        scratch_size = cbor_encoder_get_buffer_size(&origin, scratch_area);
+        if (scratch_size == 0)
+        {
+            result = -1;
+        }
+        else
+        {
+            /*
+             * Do second-stage encode - take the scratch buffer and use it as the content of the extension block
+             */
+            mpool_start_stream_init(&v7_state.mps, pool, mpool_stream_dir_write, logical->canonical_block.crctype);
+            cbor_encoder_init_writer(&origin, v7_encoder_write, &v7_state);
+            v7_state.cbor = &origin;
+
+            v7_encode_bp_canonical_block_buffer(&v7_state, logical, scratch_area, scratch_size);
+
+            if (!v7_state.error)
+            {
+                result = mpool_stream_tell(&v7_state.mps);
+                mpool_stream_attach(&v7_state.mps, mpool_get_canonical_block_encoded_chunks(ccb));
+            }
+            else
+            {
+                result = -1;
+            }
+
+            mpool_stream_close(&v7_state.mps);
+        }
+    }
+
+    return result;
+}

--- a/v7/v7_codec.h
+++ b/v7/v7_codec.h
@@ -1,0 +1,45 @@
+/************************************************************************
+ *
+ *  Copyright 2019 United States Government as represented by the
+ *  Administrator of the National Aeronautics and Space Administration.
+ *  All Other Rights Reserved.
+ *
+ *  This software was created at NASA's Goddard Space Flight Center.
+ *  This software is governed by the NASA Open Source Agreement and may be
+ *  used, distributed and modified only pursuant to the terms of that
+ *  agreement.
+ *
+ *************************************************************************/
+
+#ifndef v7_codec_h
+#define v7_codec_h
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include "bplib.h"
+#include "v7_mpool.h"
+
+/*
+ * On the decode side of things, the bundle buffer is passed in from the network/CLA and all that is known will
+ * be a pointer and size.  The first block is always supposed to be primary (per BP) and every block thereafter
+ * can be assumed canonical.  Payload of the bundle will be recorded as an offset and size into that block, there
+ * is no separate output.
+ */
+int v7_block_decode_pri(mpool_t *pool, mpool_cache_primary_block_t *cpb, const void *data_ptr, size_t data_size);
+int v7_block_decode_canonical(mpool_t *pool, mpool_cache_canonical_block_t *ccb, const void *data_ptr,
+                              size_t data_size);
+
+/*
+ * On the encode side of things, the block types are known ahead of time.  Encoding of a payload block is separate
+ * because the data needs to be passed in, but for all other canonical block types all the information should already be
+ * in the logical data - so nothing extra is needed (but this may change as more block types get implemented, too).
+ * One possible option would be to pass in NULL/0 for the block types that do not have separate data, to keep the APIs
+ * more consistent.
+ */
+int v7_block_encode_pri(mpool_t *pool, mpool_cache_primary_block_t *cpb);
+int v7_block_encode_pay(mpool_t *pool, mpool_cache_canonical_block_t *ccb, const void *data_ptr, size_t data_size);
+int v7_block_encode_canonical(mpool_t *pool, mpool_cache_canonical_block_t *ccb);
+
+#endif

--- a/v7/v7_mpool.c
+++ b/v7/v7_mpool.c
@@ -1,0 +1,996 @@
+/************************************************************************
+ *
+ *  Copyright 2019 United States Government as represented by the
+ *  Administrator of the National Aeronautics and Space Administration.
+ *  All Other Rights Reserved.
+ *
+ *  This software was created at NASA's Goddard Space Flight Center.
+ *  This software is governed by the NASA Open Source Agreement and may be
+ *  used, distributed and modified only pursuant to the terms of that
+ *  agreement.
+ *
+ *************************************************************************/
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include <string.h>
+#include <assert.h>
+
+#include "bplib.h"
+#include "bplib_os.h"
+#include "v7_types.h"
+#include "v7_mpool.h"
+
+typedef struct mpool_cache_refcount
+{
+    size_t count;
+} mpool_cache_refcount_t;
+
+typedef struct mpool_cache_primary_block_node
+{
+    mpool_cache_block_t         bundle_link;
+    mpool_cache_refcount_t      ref;
+    mpool_cache_primary_block_t pblock;
+} mpool_cache_primary_block_node_t;
+
+typedef struct mpool_cache_encode_block_node
+{
+    mpool_cache_block_t        chunk_link;
+    mpool_cache_encode_block_t eblock; /* variably sized, must be last */
+} mpool_cache_encode_block_node_t;
+
+typedef struct mpool_cache_canonical_block_node
+{
+    mpool_cache_block_t           cblock_link;
+    mpool_cache_refcount_t        ref;
+    mpool_cache_canonical_block_t cblock;
+} mpool_cache_canonical_block_node_t;
+
+typedef struct mpool_cache_primary_block_ref_node_t
+{
+    mpool_cache_block_t               bundle_link;
+    mpool_cache_primary_block_node_t *pblocknode;
+} mpool_cache_primary_block_ref_node_t;
+
+typedef struct mpool_cache_canonical_block_ref_node_t
+{
+    mpool_cache_block_t                 cblock_link;
+    mpool_cache_canonical_block_node_t *cblocknode;
+} mpool_cache_canonical_block_ref_node_t;
+
+typedef union mpool_cache_any_buffer
+{
+    mpool_cache_block_t                    link;
+    mpool_cache_primary_block_node_t       primary;
+    mpool_cache_primary_block_ref_node_t   primary_ref;
+    mpool_cache_canonical_block_node_t     canonical;
+    mpool_cache_canonical_block_ref_node_t canonical_ref;
+    mpool_cache_encode_block_node_t        encoded;
+    uint8_t                                max_content[BP_MPOOL_MAX_ENCODED_CHUNK_SIZE];
+} mpool_cache_any_buffer_t;
+
+struct mpool
+{
+    size_t                   num_bufs;
+    size_t                   buffer_size;
+    mpool_cache_block_t      free_blocks;
+    mpool_cache_block_t      common_blocks;
+    mpool_cache_block_t      outgoing_bundles;
+    mpool_cache_block_t      incoming_bundles;
+    mpool_cache_any_buffer_t first_buffer;
+};
+
+static void mpool_decr_refcount(mpool_t *pool, mpool_cache_block_t *cb);
+
+#define MPOOL_ENCODE_CHUNK_CAPACITY \
+    (sizeof(mpool_cache_any_buffer_t) - offsetof(mpool_cache_encode_block_node_t, eblock.content_start))
+
+size_t mpool_get_encode_data_capacity(const mpool_cache_encode_block_t *ceb)
+{
+    return MPOOL_ENCODE_CHUNK_CAPACITY;
+}
+
+void mpool_link_reset(mpool_cache_block_t *link, mpool_cache_blocktype_t type)
+{
+    link->type = type;
+    link->next = link;
+    link->prev = link;
+}
+
+void mpool_insert_after(mpool_cache_block_t *list, mpool_cache_block_t *node)
+{
+    node->next       = list->next;
+    node->prev       = list;
+    list->next       = node;
+    node->next->prev = node;
+}
+
+void mpool_insert_before(mpool_cache_block_t *list, mpool_cache_block_t *node)
+{
+    node->prev       = list->prev;
+    node->next       = list;
+    list->prev       = node;
+    node->prev->next = node;
+}
+
+void mpool_extract_node(mpool_cache_block_t *node)
+{
+    node->prev->next = node->next;
+    node->next->prev = node->prev;
+    node->next       = node;
+    node->prev       = node;
+}
+
+void mpool_merge_listx(mpool_cache_block_t *dest, mpool_cache_block_t *src)
+{
+    mpool_cache_block_t *dlast = dest->prev; /* last node in dest list */
+    mpool_cache_block_t *slast = src->prev;  /* last node in dest list */
+
+    /* nominally combine the two lists.
+     * NOTE: This (temporarily) yields a list with two head nodes. */
+    dlast->next = src;
+    slast->next = dest;
+    dest->prev  = slast;
+    src->prev   = dlast;
+
+    /* extract the "src" which separates them back into two lists.
+     * the src list will now be empty */
+    // x mpool_extract_node(src);
+}
+
+mpool_cache_primary_block_t *mpool_cast_primary(mpool_cache_block_t *cb)
+{
+    if (cb != NULL)
+    {
+        if (cb->type == mpool_cache_blocktype_primary)
+        {
+            return &((mpool_cache_primary_block_node_t *)cb)->pblock;
+        }
+        if (cb->type == mpool_cache_blocktype_primary_ref)
+        {
+            return &((mpool_cache_primary_block_ref_node_t *)cb)->pblocknode->pblock;
+        }
+    }
+    return NULL;
+}
+
+mpool_cache_refcount_t *mpool_get_refcount(mpool_cache_block_t *cb)
+{
+    mpool_cache_any_buffer_t *cab;
+
+    if (cb != NULL)
+    {
+        cab = (mpool_cache_any_buffer_t *)cb;
+        if (cb->type == mpool_cache_blocktype_primary)
+        {
+            return &cab->primary.ref;
+        }
+        if (cb->type == mpool_cache_blocktype_primary_ref)
+        {
+            return &cab->primary_ref.pblocknode->ref;
+        }
+        if (cb->type == mpool_cache_blocktype_canonical)
+        {
+            return &cab->canonical.ref;
+        }
+        if (cb->type == mpool_cache_blocktype_canonical_ref)
+        {
+            return &cab->canonical_ref.cblocknode->ref;
+        }
+    }
+    return NULL;
+}
+
+mpool_cache_canonical_block_t *mpool_cast_canonical(mpool_cache_block_t *cb)
+{
+    mpool_cache_any_buffer_t *cab;
+
+    if (cb != NULL)
+    {
+        cab = (mpool_cache_any_buffer_t *)cb;
+
+        if (cb->type == mpool_cache_blocktype_canonical)
+        {
+            return &cab->canonical.cblock;
+        }
+        if (cb->type == mpool_cache_blocktype_canonical_ref)
+        {
+            return &cab->canonical_ref.cblocknode->cblock;
+        }
+    }
+    return NULL;
+}
+
+mpool_cache_encode_block_t *mpool_cast_encode_block(mpool_cache_block_t *cb)
+{
+    if (cb != NULL && cb->type == mpool_cache_blocktype_encoded_chunk)
+    {
+        return &((mpool_cache_encode_block_node_t *)cb)->eblock;
+    }
+    return NULL;
+}
+
+mpool_cache_block_t *mpool_get_next_outgoing_bundle(mpool_t *pool)
+{
+    mpool_cache_block_t *node = pool->outgoing_bundles.next;
+
+    /* All nodes in the outgoing list should have a linktype of primary.
+     * If not, then this means the list is empty */
+    if (node->type != mpool_cache_blocktype_primary)
+    {
+        return NULL;
+    }
+
+    return node;
+}
+
+mpool_cache_block_t *mpool_get_next_incoming_bundle(mpool_t *pool)
+{
+    mpool_cache_block_t *node = pool->incoming_bundles.next;
+
+    /* All nodes in the incoming list should have a linktype of primary.
+     * If not, then this means the list is empty */
+    if (node->type != mpool_cache_blocktype_primary)
+    {
+        return NULL;
+    }
+
+    return node;
+}
+
+mpool_cache_block_t *mpool_alloc_primary_block(mpool_t *pool)
+{
+    mpool_cache_block_t              *node = pool->free_blocks.next;
+    mpool_cache_primary_block_node_t *cpbn;
+
+    /* All nodes in the free list should have a linktype of undefined.
+     * If not, then this means the list is empty */
+    if (node->type != mpool_cache_blocktype_undefined)
+    {
+        return NULL;
+    }
+
+    /* extract the node from the free list, and reconfigure it as a pri block */
+    mpool_extract_node(node);
+
+    node->type = mpool_cache_blocktype_primary;
+    cpbn       = (mpool_cache_primary_block_node_t *)node;
+
+    mpool_link_reset(&cpbn->pblock.cblock_list, mpool_cache_blocktype_head);
+    mpool_link_reset(&cpbn->pblock.chunk_list, mpool_cache_blocktype_head);
+
+    /* wipe the logical content to be sure no stale data exists */
+    memset(&cpbn->pblock.content_start, 0, sizeof(cpbn->pblock.content_start));
+
+    return node;
+}
+
+mpool_cache_block_t *mpool_alloc_canonical_block(mpool_t *pool)
+{
+    mpool_cache_block_t                *node = pool->free_blocks.next;
+    mpool_cache_canonical_block_node_t *ccb;
+
+    /* All nodes in the free list should have a linktype of undefined.
+     * If not, then this means the list is empty */
+    if (node->type != mpool_cache_blocktype_undefined)
+    {
+        return NULL;
+    }
+
+    /* extract the node from the free list, and reconfigure it as a canonical block */
+    mpool_extract_node(node);
+
+    node->type = mpool_cache_blocktype_canonical;
+    ccb        = (mpool_cache_canonical_block_node_t *)node;
+
+    mpool_link_reset(&ccb->cblock.chunk_list, mpool_cache_blocktype_head);
+
+    /* wipe the logical content to be sure no stale data exists */
+    memset(&ccb->cblock.content_start, 0, sizeof(ccb->cblock.content_start));
+    mpool_set_canonical_block_encoded_content_detail(&ccb->cblock, 0, 0);
+
+    return node;
+}
+
+mpool_cache_block_t *mpool_alloc_encode_block(mpool_t *pool)
+{
+    mpool_cache_block_t             *node = pool->free_blocks.next;
+    mpool_cache_encode_block_node_t *ceb;
+
+    /* All nodes in the free list should have a linktype of undefined.
+     * If not, then this means the list is empty */
+    if (node->type != mpool_cache_blocktype_undefined)
+    {
+        return NULL;
+    }
+
+    /* extract the node from the free list, and reconfigure it as a canonical block */
+    mpool_extract_node(node);
+
+    node->type = mpool_cache_blocktype_encoded_chunk;
+    ceb        = (mpool_cache_encode_block_node_t *)node;
+
+    ceb->eblock.encoded_length = 0;
+
+    return node;
+}
+
+void mpool_append_encode_block(mpool_cache_block_t *head, mpool_cache_block_t *blk)
+{
+    assert(blk->type == mpool_cache_blocktype_encoded_chunk);
+    mpool_insert_before(head, blk);
+}
+
+void mpool_return_single_encode_block(mpool_t *pool, mpool_cache_block_t *blk)
+{
+    assert(blk->type == mpool_cache_blocktype_encoded_chunk);
+    mpool_extract_node(blk);
+    blk->type = mpool_cache_blocktype_undefined;
+    mpool_insert_before(&pool->free_blocks, blk);
+}
+
+void mpool_return_all_encode_blocks(mpool_t *pool, mpool_cache_block_t *list)
+{
+    mpool_cache_block_t *ptr;
+
+    assert(list->type == mpool_cache_blocktype_head);
+
+    ptr = list->next;
+    while (ptr->type != mpool_cache_blocktype_head)
+    {
+        /*
+         * all nodes should be of the encoded_chunk type here ---
+         * other block types may contain other refs, so its important to ONLY use this
+         * routine for encoded chunks.  Use mpool_decr_refcount() to collect ANY type of block.
+         */
+        assert(ptr->type == mpool_cache_blocktype_encoded_chunk);
+        ptr->type = mpool_cache_blocktype_undefined;
+        ptr       = ptr->next;
+    }
+
+    mpool_merge_listx(&pool->free_blocks, list);
+    mpool_extract_node(list);
+}
+
+void mpool_return_all_blocks_in_list(mpool_t *pool, mpool_cache_block_t *list)
+{
+    mpool_cache_block_t *ptr;
+
+    assert(list->type == mpool_cache_blocktype_head);
+
+    ptr = list->next;
+    while (ptr->type != mpool_cache_blocktype_head)
+    {
+        mpool_decr_refcount(pool, ptr);
+
+        /* whether it was a ref or direct block, this block can get freed */
+        ptr->type = mpool_cache_blocktype_undefined;
+        ptr       = ptr->next;
+    }
+
+    mpool_merge_listx(&pool->free_blocks, list);
+    mpool_extract_node(list);
+}
+
+/*
+ * Decrement the canonical block refcount
+ * The refcount allows a single representation in memory to be virtually
+ * included in many different bundles at once (useful for e.g. previous hop)
+ *
+ * This has no effect if called on a non-canonical block
+ */
+void mpool_decr_refcount(mpool_t *pool, mpool_cache_block_t *cb)
+{
+    mpool_cache_canonical_block_node_t *ccbn;
+    mpool_cache_primary_block_node_t   *cpbn;
+    mpool_cache_any_buffer_t           *cab;
+    mpool_cache_refcount_t             *pref;
+    mpool_cache_block_t                *pcontent;
+
+    cab  = (mpool_cache_any_buffer_t *)cb;
+    ccbn = NULL;
+    cpbn = NULL;
+
+    /* Dereference the node if indirect */
+    switch (cb->type)
+    {
+        case mpool_cache_blocktype_canonical:
+        {
+            ccbn = &cab->canonical;
+            break;
+        }
+        case mpool_cache_blocktype_primary:
+        {
+            cpbn = &cab->primary;
+            break;
+        }
+        case mpool_cache_blocktype_canonical_ref:
+        {
+            ccbn                          = cab->canonical_ref.cblocknode;
+            cab->canonical_ref.cblocknode = NULL; /* this ref is going away */
+            break;
+        }
+        case mpool_cache_blocktype_primary_ref:
+        {
+            cpbn                        = cab->primary_ref.pblocknode;
+            cab->primary_ref.pblocknode = NULL; /* this ref is going away */
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    if (cpbn)
+    {
+        pref     = &cpbn->ref;
+        pcontent = &cpbn->bundle_link;
+    }
+    else if (ccbn)
+    {
+        pref     = &ccbn->ref;
+        pcontent = &ccbn->cblock_link;
+    }
+    else
+    {
+        pref     = NULL;
+        pcontent = cb;
+    }
+
+    if (pref != NULL && pref->count > 0)
+    {
+        --pref->count;
+    }
+
+    /* If not refcounted OR if the refcount got to zero, then clean up the object  */
+    /* TBD: part of this block recovery could also be deferred to a garbage collector */
+    if (pref == NULL || pref->count == 0)
+    {
+        /* Collect the content chunks too */
+        if (cpbn != NULL)
+        {
+            mpool_return_all_blocks_in_list(pool, &cpbn->pblock.cblock_list);
+            mpool_return_all_encode_blocks(pool, &cpbn->pblock.chunk_list);
+        }
+        if (ccbn != NULL)
+        {
+            mpool_return_all_encode_blocks(pool, &ccbn->cblock.chunk_list);
+        }
+
+        /* ONLY if this was a ref node, delete the content here */
+        /* The ref itself will be removed by the caller */
+        if (pcontent != cb)
+        {
+            /* now reset this node and return it to the free block list */
+            mpool_extract_node(pcontent);
+            pcontent->type = mpool_cache_blocktype_undefined;
+            mpool_insert_before(&pool->free_blocks, pcontent);
+        }
+    }
+}
+
+void mpool_return_block(mpool_t *pool, mpool_cache_block_t *cb)
+{
+    mpool_decr_refcount(pool, cb);
+}
+
+size_t mpool_sum_encoded_size(mpool_cache_block_t *list)
+{
+    mpool_cache_block_t        *blk;
+    mpool_cache_encode_block_t *ceb;
+    size_t                      size_sum;
+
+    size_sum = 0;
+    blk      = list;
+    while (true)
+    {
+        blk = mpool_get_next_block(blk);
+        ceb = mpool_cast_encode_block(blk);
+        if (ceb == NULL)
+        {
+            break;
+        }
+        size_sum += ceb->encoded_length;
+    }
+
+    return size_sum;
+}
+
+size_t mpool_sum_full_bundle_size(mpool_cache_primary_block_t *cpb)
+{
+    mpool_cache_block_t           *blk;
+    mpool_cache_canonical_block_t *ccb;
+    size_t                         size_sum;
+
+    size_sum = mpool_sum_encoded_size(&cpb->chunk_list);
+    blk      = &cpb->cblock_list;
+    while (true)
+    {
+        blk = mpool_get_next_block(blk);
+        ccb = mpool_cast_canonical(blk);
+        if (ccb == NULL)
+        {
+            break;
+        }
+        size_sum += mpool_sum_encoded_size(&ccb->chunk_list);
+    }
+
+    return size_sum;
+}
+
+size_t mpool_copy_block_chain(mpool_cache_block_t *list, void *out_ptr, size_t max_out_size, size_t seek_start,
+                              size_t max_count)
+{
+    mpool_cache_block_t        *blk;
+    mpool_cache_encode_block_t *ceb;
+    uint8_t                    *curr_ptr;
+    const uint8_t              *src_ptr;
+    size_t                      remain_sz;
+    size_t                      chunk_sz;
+    size_t                      seek_left;
+    size_t                      data_left;
+
+    remain_sz = max_out_size;
+    curr_ptr  = out_ptr;
+    seek_left = seek_start;
+    data_left = max_count;
+    blk       = list;
+    while (data_left > 0)
+    {
+        blk = mpool_get_next_block(blk);
+        ceb = mpool_cast_encode_block(blk);
+        if (ceb == NULL)
+        {
+            break;
+        }
+        chunk_sz = ceb->encoded_length;
+        if (seek_left > chunk_sz)
+        {
+            seek_left -= chunk_sz;
+        }
+        else
+        {
+            src_ptr = &ceb->content_start;
+            if (seek_left > 0)
+            {
+                src_ptr += seek_left;
+                chunk_sz -= seek_left;
+                seek_left = 0;
+            }
+
+            if (chunk_sz > data_left)
+            {
+                chunk_sz = data_left;
+            }
+
+            if (remain_sz < chunk_sz)
+            {
+                /* will not fit */
+                break;
+            }
+            memcpy(curr_ptr, src_ptr, chunk_sz);
+            curr_ptr += chunk_sz;
+            remain_sz -= chunk_sz;
+            data_left -= chunk_sz;
+        }
+    }
+
+    return max_out_size - remain_sz;
+}
+
+#ifdef jphfix
+typedef void (*mpool_canonical_block_handler_t)(mpool_cache_canonical_block_t *, void *arg);
+
+void mpool_foreach_canonical_block(bp_primary_block_t *pri, mpool_canonical_block_handler_t handler, void *arg)
+{
+    mpool_cache_primary_block_t   *pri_block;
+    mpool_cache_canonical_block_t *canon_block;
+    mpool_cache_block_t           *ptr;
+
+    pri_block = mpool_container_of(pri, mpool_cache_primary_block_t);
+    assert(pri_block->bundle_link.type == mpool_cache_blocktype_primary);
+    assert(pri_block->cblock_list.type == mpool_cache_blocktype_head);
+
+    ptr = pri_block->cblock_list.next;
+    while (ptr->type != mpool_cache_blocktype_head)
+    {
+        /* all nodes should be of the canonical type here */
+        assert(ptr->type == mpool_cache_blocktype_canonical);
+        handler((mpool_cache_canonical_block_t *)ptr, arg);
+        ptr = ptr->next;
+    }
+}
+
+void mpool_append_canonical_block(bp_primary_block_t *pri, bp_canonical_block_buffer_t *canon)
+{
+    mpool_cache_primary_block_t   *pri_block;
+    mpool_cache_canonical_block_t *canon_block;
+
+    pri_block = mpool_container_of(pri, mpool_cache_primary_block_t);
+    assert(pri_block->bundle_link.type == mpool_cache_blocktype_primary);
+
+    canon_block = mpool_container_of(canon, mpool_cache_canonical_block_t);
+    assert(canon_block->cblock_link.type == mpool_cache_blocktype_canonical);
+
+    mpool_insert_before(&pri_block->cblock_list, &canon_block->cblock_link);
+}
+#endif
+
+void mpool_store_primary_block_incoming(mpool_t *pool, mpool_cache_block_t *cpb)
+{
+    assert(cpb->type == mpool_cache_blocktype_primary);
+    mpool_insert_before(&pool->incoming_bundles, cpb);
+}
+
+void mpool_store_primary_block_outgoing(mpool_t *pool, mpool_cache_block_t *cpb)
+{
+    assert(cpb->type == mpool_cache_blocktype_primary);
+    mpool_insert_before(&pool->outgoing_bundles, cpb);
+}
+
+void mpool_store_canonical_block(mpool_cache_primary_block_t *cpb, mpool_cache_block_t *blk)
+{
+    mpool_cache_canonical_block_t *ccb;
+
+    /* this should only be invoked w/canonical blocks.  Anything else is a bug. */
+    ccb = mpool_cast_canonical(blk);
+    assert(ccb);
+
+    /*
+     * TBD on block ordering requirements.  The BPv7 spec says the payload should be last,
+     * but other blocks may appear in any order.  It is not clear if there is any reason
+     * to be more specific about block order.
+     *
+     * For now, if the block being inserted is payload, put it last, otherwise put it first.
+     */
+
+    if (mpool_get_canonical_block_logical(ccb)->canonical_block.blockType == bp_blocktype_payloadBlock)
+    {
+        /* this puts it last */
+        mpool_insert_before(&cpb->cblock_list, blk);
+    }
+    else
+    {
+        /* this puts it first */
+        mpool_insert_after(&cpb->cblock_list, blk);
+    }
+}
+
+void mpool_start_stream_init(mpool_stream_t *mps, mpool_t *pool, mpool_stream_dir_t dir, bp_crctype_t crctype)
+{
+    memset(mps, 0, sizeof(*mps));
+
+    mpool_link_reset(&mps->head, mpool_cache_blocktype_head);
+
+    mps->dir       = dir;
+    mps->pool      = pool;
+    mps->last_eblk = &mps->head;
+
+    switch (crctype)
+    {
+        case bp_crctype_CRC16:
+            mps->crc_params = &BPLIB_CRC16_X25;
+            break;
+        case bp_crctype_CRC32C:
+            mps->crc_params = &BPLIB_CRC32_CASTAGNOLI;
+            break;
+        default:
+            mps->crc_params = &BPLIB_CRC_NONE;
+            break;
+    }
+
+    mps->crcval = bplib_crc_initial_value(mps->crc_params);
+}
+
+size_t mpool_stream_write(mpool_stream_t *mps, const void *data, size_t size)
+{
+    mpool_cache_block_t        *next_block;
+    mpool_cache_encode_block_t *curr_eblk;
+    const uint8_t              *chunk_p;
+    uint8_t                    *out_p;
+    size_t                      chunk_sz;
+    size_t                      remain_sz;
+
+    if (mps->dir != mpool_stream_dir_write || size == 0)
+    {
+        return 0;
+    }
+
+    remain_sz = size;
+    chunk_p   = data;
+    while (remain_sz > 0)
+    {
+        /* If no block is ready, get one now */
+        if (mps->curr_pos >= mps->curr_limit)
+        {
+            next_block = mpool_alloc_encode_block(mps->pool);
+            if (next_block == NULL)
+            {
+                break;
+            }
+
+            mpool_append_encode_block(&mps->head, next_block);
+
+            mps->last_eblk  = next_block;
+            mps->curr_pos   = 0;
+            mps->curr_limit = MPOOL_ENCODE_CHUNK_CAPACITY;
+        }
+
+        curr_eblk = mpool_cast_encode_block(mps->last_eblk);
+
+        chunk_sz = mps->curr_limit - mps->curr_pos;
+        if (chunk_sz > remain_sz)
+        {
+            chunk_sz = remain_sz;
+        }
+
+        out_p = &curr_eblk->content_start + mps->curr_pos;
+        memcpy(out_p, chunk_p, chunk_sz);
+        mps->crcval = bplib_crc_update(mps->crc_params, mps->crcval, out_p, chunk_sz);
+
+        mps->curr_pos += chunk_sz;
+        curr_eblk->encoded_length = mps->curr_pos;
+        mps->stream_position += chunk_sz;
+        remain_sz -= chunk_sz;
+        chunk_p += chunk_sz;
+    }
+
+    return (size - remain_sz);
+}
+
+size_t mpool_stream_seek(mpool_stream_t *mps, size_t target_position)
+{
+    mpool_cache_block_t        *next_block;
+    mpool_cache_encode_block_t *curr_eblk;
+    size_t                      block_avail;
+    size_t                      chunk_sz;
+
+    /*
+     * Loop to move the stream position forward
+     * On a read this should just advance through the existing data
+     * On a write this should generate zeros to fill the gap
+     * If a CRC calculation is included, this will update the CRC accordingly
+     */
+    while (target_position > mps->stream_position)
+    {
+        chunk_sz = target_position - mps->stream_position;
+
+        /* If no block is ready, get one now */
+        if (mps->curr_pos >= mps->curr_limit)
+        {
+            if (mps->dir == mpool_stream_dir_read)
+            {
+                next_block = mpool_get_next_block(mps->last_eblk);
+            }
+            else if (mps->dir == mpool_stream_dir_write)
+            {
+                next_block = mpool_alloc_encode_block(mps->pool);
+            }
+            else
+            {
+                next_block = NULL;
+            }
+
+            curr_eblk = mpool_cast_encode_block(next_block);
+            if (curr_eblk == NULL)
+            {
+                break;
+            }
+
+            mps->curr_pos  = 0;
+            mps->last_eblk = next_block;
+
+            if (mps->dir == mpool_stream_dir_write)
+            {
+                mpool_append_encode_block(&mps->head, next_block);
+                mps->curr_limit = mpool_get_encode_data_capacity(curr_eblk);
+            }
+            else
+            {
+                mps->curr_limit = mpool_get_encode_data_actual_size(curr_eblk);
+            }
+        }
+        else
+        {
+            curr_eblk = mpool_cast_encode_block(mps->last_eblk);
+        }
+
+        block_avail = mps->curr_limit - mps->curr_pos;
+
+        if (block_avail < chunk_sz)
+        {
+            chunk_sz = block_avail;
+        }
+
+        /*
+         * On a write stream this must zero-fill the data
+         */
+        if (mps->dir == mpool_stream_dir_write)
+        {
+            memset(&curr_eblk->content_start + mps->curr_pos, 0, chunk_sz);
+            curr_eblk->encoded_length += chunk_sz;
+        }
+
+        mps->crcval =
+            bplib_crc_update(mps->crc_params, mps->crcval, &curr_eblk->content_start + mps->curr_pos, chunk_sz);
+        mps->curr_pos += chunk_sz;
+        mps->stream_position += chunk_sz;
+    }
+
+    /*
+     * Loop to move the stream position backwards
+     * On a read this should just back up through the existing data
+     * On a write this should drop/delete data
+     * If a CRC calculation is being done, this will invalidate the CRC
+     */
+    while (target_position < mps->stream_position)
+    {
+        chunk_sz = mps->stream_position - target_position;
+
+        if (mps->curr_pos == 0)
+        {
+            /* Need to move back a block */
+            next_block = mpool_get_prev_block(mps->last_eblk);
+            curr_eblk  = mpool_cast_encode_block(next_block);
+            if (curr_eblk == NULL)
+            {
+                break;
+            }
+
+            if (mps->dir == mpool_stream_dir_write)
+            {
+                mpool_return_single_encode_block(mps->pool, mps->last_eblk);
+                mps->curr_limit = mpool_get_encode_data_capacity(curr_eblk);
+                mps->curr_pos   = mpool_get_encode_data_capacity(curr_eblk);
+            }
+            else
+            {
+                mps->curr_limit = mpool_get_encode_data_actual_size(curr_eblk);
+                mps->curr_pos   = mps->curr_limit;
+            }
+
+            mps->last_eblk = next_block;
+        }
+
+        if (mps->curr_pos < chunk_sz)
+        {
+            chunk_sz = mps->curr_pos;
+        }
+
+        mps->curr_pos -= chunk_sz;
+        mps->stream_position -= chunk_sz;
+    }
+
+    return mps->stream_position;
+}
+
+size_t mpool_stream_read(mpool_stream_t *mps, void *data, size_t size)
+{
+    mpool_cache_block_t        *next_block;
+    mpool_cache_encode_block_t *curr_eblk;
+    const uint8_t              *in_p;
+    uint8_t                    *chunk_p;
+    size_t                      chunk_sz;
+    size_t                      remain_sz;
+
+    if (mps->dir != mpool_stream_dir_read || size == 0)
+    {
+        return 0;
+    }
+
+    remain_sz = size;
+    chunk_p   = data;
+    while (remain_sz > 0)
+    {
+        /* If no block is ready, get one now */
+        if (mps->curr_pos >= mps->curr_limit)
+        {
+            next_block = mpool_get_next_block(mps->last_eblk);
+            curr_eblk  = mpool_cast_encode_block(next_block);
+            if (curr_eblk == NULL)
+            {
+                /* end of stream */
+                break;
+            }
+
+            mps->last_eblk  = next_block;
+            mps->curr_limit = mpool_get_encode_data_actual_size(curr_eblk);
+            mps->curr_pos   = 0;
+        }
+        else
+        {
+            curr_eblk = mpool_cast_encode_block(mps->last_eblk);
+        }
+
+        chunk_sz = mps->curr_limit - mps->curr_pos;
+        if (chunk_sz > remain_sz)
+        {
+            chunk_sz = remain_sz;
+        }
+
+        in_p = &curr_eblk->content_start + mps->curr_pos;
+        memcpy(chunk_p, in_p, chunk_sz);
+        mps->crcval = bplib_crc_update(mps->crc_params, mps->crcval, in_p, chunk_sz);
+
+        mps->curr_pos += chunk_sz;
+        mps->stream_position += chunk_sz;
+        remain_sz -= chunk_sz;
+        chunk_p += chunk_sz;
+    }
+
+    return (size - remain_sz);
+}
+
+void mpool_stream_attach(mpool_stream_t *mps, mpool_cache_block_t *head)
+{
+    mpool_merge_listx(head, &mps->head);
+    mpool_extract_node(&mps->head);
+
+    mps->last_eblk       = &mps->head;
+    mps->curr_limit      = 0;
+    mps->curr_pos        = 0;
+    mps->stream_position = 0;
+    mps->crcval          = bplib_crc_initial_value(mps->crc_params);
+}
+
+uint8_t mpool_stream_get_crc_bit_size(const mpool_stream_t *mps)
+{
+    return bplib_crc_get_width(mps->crc_params);
+}
+
+bp_crcval_t mpool_stream_get_current_crc(const mpool_stream_t *mps)
+{
+    return bplib_crc_finalize(mps->crc_params, mps->crcval);
+}
+
+void mpool_stream_close(mpool_stream_t *mps)
+{
+    /* discard anything that wasn't saved (will be a no-op if it was saved) */
+    mpool_return_all_encode_blocks(mps->pool, &mps->head);
+}
+
+mpool_t *mpool_create(void *pool_mem, size_t pool_size)
+{
+    mpool_t                  *pool;
+    size_t                    remain;
+    mpool_cache_any_buffer_t *pchunk;
+
+    /* this is just a sanity check, a pool that has only 1 block will not
+     * be useful for anything, but it can at least be created */
+    if (pool_mem == NULL || pool_size < sizeof(mpool_t))
+    {
+        /* pool memory too small */
+        return NULL;
+    }
+
+    /* wiping the entire memory might be overkill, but it is only done once
+     * at start up, and this may also help verify that the memory "works" */
+    memset(pool_mem, 0, pool_size);
+
+    pool = pool_mem;
+
+    /* the block lists are circular, as this reduces
+     * complexity of operations (never a null pointer) */
+    pool->buffer_size = sizeof(mpool_cache_any_buffer_t);
+    mpool_link_reset(&pool->free_blocks, mpool_cache_blocktype_head);
+    mpool_link_reset(&pool->outgoing_bundles, mpool_cache_blocktype_head);
+    mpool_link_reset(&pool->incoming_bundles, mpool_cache_blocktype_head);
+
+    pchunk = &pool->first_buffer;
+    remain = pool_size - offsetof(mpool_t, first_buffer);
+
+    while (remain >= sizeof(mpool_cache_any_buffer_t))
+    {
+        mpool_insert_before(&pool->free_blocks, &pchunk->link);
+        remain -= sizeof(mpool_cache_any_buffer_t);
+        ++pchunk;
+        ++pool->num_bufs;
+    }
+
+    printf("%s(): created pool of size %zu, with %zu chunks\n", __func__, pool_size, pool->num_bufs);
+
+    return pool;
+}

--- a/v7/v7_mpool.h
+++ b/v7/v7_mpool.h
@@ -1,0 +1,264 @@
+/************************************************************************
+ *
+ *  Copyright 2019 United States Government as represented by the
+ *  Administrator of the National Aeronautics and Space Administration.
+ *  All Other Rights Reserved.
+ *
+ *  This software was created at NASA's Goddard Space Flight Center.
+ *  This software is governed by the NASA Open Source Agreement and may be
+ *  used, distributed and modified only pursuant to the terms of that
+ *  agreement.
+ *
+ *************************************************************************/
+
+#ifndef bplib_mpool_h
+#define bplib_mpool_h
+
+#include <string.h>
+
+#include "bplib.h"
+#include "v7_types.h"
+#include "crc.h"
+
+/*
+ * A note about encoded chunk size -
+ * All data chunks, including logical (non-encoded) primary and canonical block info,
+ * as well as encoded blobs, get stored in the same size record.  These are then chained
+ * together to hold larger items.
+ */
+#define BP_MPOOL_MAX_ENCODED_CHUNK_SIZE 256
+
+/*
+ * The 3 basic types of blocks which are cacheable in the mpool
+ */
+typedef struct mpool_cache_primary_block       mpool_cache_primary_block_t;
+typedef struct mpool_cache_canonical_block     mpool_cache_canonical_block_t;
+typedef struct mpool_cache_canonical_ref_block mpool_cache_canonical_ref_block_t;
+typedef struct mpool_cache_encode_block        mpool_cache_encode_block_t;
+
+typedef struct mpool_cache_block mpool_cache_block_t;
+typedef struct mpool             mpool_t;
+
+typedef enum mpool_cache_blocktype
+{
+    mpool_cache_blocktype_undefined,
+    mpool_cache_blocktype_head,
+    mpool_cache_blocktype_primary,
+    mpool_cache_blocktype_primary_ref,
+    mpool_cache_blocktype_canonical,
+    mpool_cache_blocktype_canonical_ref,
+    mpool_cache_blocktype_encoded_chunk
+} mpool_cache_blocktype_t;
+
+struct mpool_cache_block
+{
+    mpool_cache_blocktype_t   type;
+    struct mpool_cache_block *next;
+    struct mpool_cache_block *prev;
+};
+
+typedef enum mpool_stream_dir
+{
+    mpool_stream_dir_undefined,
+    mpool_stream_dir_write,
+    mpool_stream_dir_read
+} mpool_stream_dir_t;
+
+typedef struct mpool_stream
+{
+    mpool_stream_dir_t      dir;
+    mpool_t                *pool;
+    mpool_cache_block_t    *last_eblk;
+    mpool_cache_block_t     head;
+    size_t                  curr_pos;
+    size_t                  curr_limit;
+    size_t                  stream_position;
+    bplib_crc_parameters_t *crc_params;
+    bp_crcval_t             crcval;
+} mpool_stream_t;
+
+/*
+ * Note that all cache nodes must begin with a
+ * mpool_cache_block_t structure.  There may be
+ * additional mpool_cache_block_t's as well,
+ * but the first is assumed to always be there,
+ * to matter which type of link it is.
+ *
+ * They also must have a member named "content_start" which
+ * reflects the actual structure/pointer returned to the user.
+ */
+
+//#define mpool_container_of(p, type) (type*)(((uint8_t*)p) - offsetof(type, content_start))
+
+typedef struct mpool_cache_primary_block
+{
+    mpool_cache_block_t cblock_list;
+    mpool_cache_block_t chunk_list;
+    bp_primary_block_t  content_start;
+} mpool_cache_primary_block_t;
+
+typedef struct mpool_cache_canonical_block
+{
+    mpool_cache_block_t         chunk_list;
+    size_t                      encoded_content_offset;
+    size_t                      encoded_content_length;
+    bp_canonical_block_buffer_t content_start;
+} mpool_cache_canonical_block_t;
+
+typedef struct mpool_cache_encode_block
+{
+    size_t  encoded_length; /* actual length of content */
+    uint8_t content_start;  /* variably sized, not using C99 flexible array member due to restrictions it causes */
+} mpool_cache_encode_block_t;
+
+static inline bp_primary_block_t *mpool_get_pri_block_logical(mpool_cache_primary_block_t *cpb)
+{
+    return &cpb->content_start;
+}
+
+static inline mpool_cache_block_t *mpool_get_pri_block_encoded_chunks(mpool_cache_primary_block_t *cpb)
+{
+    return &cpb->chunk_list;
+}
+
+static inline mpool_cache_block_t *mpool_get_canonical_block_list(mpool_cache_primary_block_t *cpb)
+{
+    return &cpb->cblock_list;
+}
+
+static inline bp_canonical_block_buffer_t *mpool_get_canonical_block_logical(mpool_cache_canonical_block_t *ccb)
+{
+    return &ccb->content_start;
+}
+
+static inline mpool_cache_block_t *mpool_get_canonical_block_encoded_chunks(mpool_cache_canonical_block_t *ccb)
+{
+    return &ccb->chunk_list;
+}
+
+static inline void mpool_set_canonical_block_encoded_content_detail(mpool_cache_canonical_block_t *ccb, size_t offset,
+                                                                    size_t length)
+{
+    ccb->encoded_content_offset = offset;
+    ccb->encoded_content_length = length;
+}
+
+static inline size_t mpool_get_canonical_block_encoded_content_length(const mpool_cache_canonical_block_t *ccb)
+{
+    return ccb->encoded_content_length;
+}
+
+static inline size_t mpool_get_canonical_block_encoded_content_offset(const mpool_cache_canonical_block_t *ccb)
+{
+    return ccb->encoded_content_offset;
+}
+
+static inline mpool_cache_block_t *mpool_get_next_block(mpool_cache_block_t *cb)
+{
+    return cb->next;
+}
+
+static inline mpool_cache_block_t *mpool_get_prev_block(mpool_cache_block_t *cb)
+{
+    return cb->prev;
+}
+
+static inline bool mpool_is_encode_block(mpool_cache_block_t *cb)
+{
+    return (cb->type == mpool_cache_blocktype_encoded_chunk);
+}
+
+static inline bool mpool_is_pri_block(mpool_cache_block_t *cb)
+{
+    return (cb->type == mpool_cache_blocktype_primary);
+}
+
+static inline bool mpool_is_canonical_block(mpool_cache_block_t *cb)
+{
+    return (cb->type == mpool_cache_blocktype_canonical);
+}
+
+static inline bool mpool_is_direct_block(mpool_cache_block_t *cb)
+{
+    return (cb->type == mpool_cache_blocktype_primary || cb->type == mpool_cache_blocktype_canonical ||
+            cb->type == mpool_cache_blocktype_encoded_chunk);
+}
+
+static inline bool mpool_is_indirect_block(mpool_cache_block_t *cb)
+{
+    return (cb->type == mpool_cache_blocktype_primary_ref || cb->type == mpool_cache_blocktype_canonical_ref);
+}
+
+static inline bool mpool_is_any_content_node(mpool_cache_block_t *cb)
+{
+    return (cb->type > mpool_cache_blocktype_head);
+}
+
+static inline void *mpool_get_encode_base_ptr(mpool_cache_encode_block_t *ceb)
+{
+    return &ceb->content_start;
+}
+
+static inline size_t mpool_get_encode_data_actual_size(const mpool_cache_encode_block_t *ceb)
+{
+    return ceb->encoded_length;
+}
+
+static inline void mpool_set_encode_data_size(mpool_cache_encode_block_t *ceb, size_t length)
+{
+    ceb->encoded_length = length;
+}
+
+size_t mpool_get_encode_data_capacity(const mpool_cache_encode_block_t *ceb);
+
+static inline size_t mpool_get_encode_data_available(const mpool_cache_encode_block_t *ceb)
+{
+    return mpool_get_encode_data_capacity(ceb) - mpool_get_encode_data_actual_size(ceb);
+}
+
+mpool_cache_primary_block_t   *mpool_cast_primary(mpool_cache_block_t *cb);
+mpool_cache_canonical_block_t *mpool_cast_canonical(mpool_cache_block_t *cb);
+mpool_cache_encode_block_t    *mpool_cast_encode_block(mpool_cache_block_t *cb);
+
+mpool_cache_block_t *mpool_get_next_outgoing_bundle(mpool_t *pool);
+mpool_cache_block_t *mpool_get_next_incoming_bundle(mpool_t *pool);
+
+mpool_cache_block_t *mpool_alloc_primary_block(mpool_t *pool);
+mpool_cache_block_t *mpool_alloc_canonical_block(mpool_t *pool);
+mpool_cache_block_t *mpool_alloc_encode_block(mpool_t *pool);
+
+void   mpool_start_stream_init(mpool_stream_t *mps, mpool_t *pool, mpool_stream_dir_t dir, bp_crctype_t crctype);
+size_t mpool_stream_write(mpool_stream_t *mps, const void *data, size_t size);
+size_t mpool_stream_read(mpool_stream_t *mps, void *data, size_t size);
+size_t mpool_stream_seek(mpool_stream_t *mps, size_t position);
+void   mpool_stream_attach(mpool_stream_t *mps, mpool_cache_block_t *head);
+static inline bplib_crc_parameters_t *mpool_stream_get_crc_params(const mpool_stream_t *mps)
+{
+    return mps->crc_params;
+}
+static inline bp_crcval_t mpool_stream_get_intermediate_crc(const mpool_stream_t *mps)
+{
+    return mps->crcval;
+}
+static inline size_t mpool_stream_tell(const mpool_stream_t *mps)
+{
+    return mps->stream_position;
+}
+void mpool_stream_close(mpool_stream_t *mps);
+
+void mpool_append_encode_block(mpool_cache_block_t *head, mpool_cache_block_t *blk);
+
+void mpool_store_primary_block_incoming(mpool_t *pool, mpool_cache_block_t *cpb);
+void mpool_store_primary_block_outgoing(mpool_t *pool, mpool_cache_block_t *cpb);
+void mpool_store_canonical_block(mpool_cache_primary_block_t *cpb, mpool_cache_block_t *ccb);
+
+void mpool_return_block(mpool_t *pool, mpool_cache_block_t *blk);
+
+size_t mpool_sum_encode_size(mpool_cache_block_t *list);
+size_t mpool_sum_full_bundle_size(mpool_cache_primary_block_t *cpb);
+size_t mpool_copy_block_chain(mpool_cache_block_t *list, void *out_ptr, size_t max_out_size, size_t seek_start,
+                              size_t max_count);
+
+mpool_t *mpool_create(void *pool_mem, size_t pool_size);
+
+#endif

--- a/v7/v7_types.h
+++ b/v7/v7_types.h
@@ -1,0 +1,250 @@
+/************************************************************************
+ *
+ *  Copyright 2022 United States Government as represented by the
+ *  Administrator of the National Aeronautics and Space Administration.
+ *  All Other Rights Reserved.
+ *
+ *  This software was created at NASA's Goddard Space Flight Center.
+ *  This software is governed by the NASA Open Source Agreement and may be
+ *  used, distributed and modified only pursuant to the terms of that
+ *  agreement.
+ *
+ *************************************************************************/
+
+#ifndef v7_types_h
+#define v7_types_h
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include "bplib.h"
+#include "crc.h"
+
+/******************************************************************************
+ TYPEDEFS
+ ******************************************************************************/
+
+/*
+ * Native Type for most BP integers.
+ * TBD: does this need an option to be smaller?
+ */
+typedef uint64_t bp_integer_t;
+
+typedef uint8_t bp_blocknum_t;
+
+typedef enum bp_blocktype
+{
+    bp_blocktype_undefined                   = 0,
+    bp_blocktype_payloadBlock                = 1,
+    bp_blocktype_bundleAuthenicationBlock    = 2,
+    bp_blocktype_payloadIntegrityBlock       = 3,
+    bp_blocktype_payloadConfidentialityBlock = 4,
+    bp_blocktype_previousHopInsertionBlock   = 5,
+    bp_blocktype_previousNode                = 6,
+    bp_blocktype_bundleAge                   = 7,
+    bp_blocktype_metadataExtensionBlock      = 8,
+    bp_blocktype_extensionSecurityBlock      = 9,
+    bp_blocktype_hopCount                    = 10,
+    bp_blocktype_MAX                         = 11
+} bp_blocktype_t;
+
+typedef bp_integer_t bp_dtntime_t;
+typedef bp_integer_t bp_sequencenumber_t;
+
+typedef enum bp_iana_uri_scheme
+{
+    bp_iana_uri_scheme_undefined = 0,
+    bp_iana_uri_scheme_ipn       = 2
+} bp_iana_uri_scheme_t;
+
+typedef enum bp_endpointid_scheme
+{
+    bp_endpointid_scheme_undefined = 0,
+    bp_endpointid_scheme_ipn       = 2
+} bp_endpointid_scheme_t;
+
+typedef bp_integer_t bp_ipn_nodenumber_t;
+typedef bp_integer_t bp_ipn_servicenumber_t;
+
+typedef struct bp_ipn_uri_ssp
+{
+    bp_ipn_nodenumber_t    node_number;
+    bp_ipn_servicenumber_t service_number;
+} bp_ipn_uri_ssp_t;
+
+typedef struct bp_creation_timestamp
+{
+    bp_dtntime_t        time;
+    bp_sequencenumber_t sequence_num;
+} bp_creation_timestamp_t;
+
+/**
+ * @brief Label definitions associated with CCSDS_BP_CRCType_Enum_t
+ */
+typedef enum bp_crctype
+{
+
+    /**
+     * @brief No CRC is present.
+     */
+    bp_crctype_none = 0,
+
+    /**
+     * @brief A standard X-25 CRC-16 is present.
+     */
+    bp_crctype_CRC16 = 1,
+
+    /**
+     * @brief A CRC-32 (Castagnoli) is present.
+     */
+    bp_crctype_CRC32C = 2
+} bp_crctype_t;
+
+typedef bp_crcval_t bp_crcval_t;
+
+typedef struct bp_bundle_processing_control_flags
+{
+
+    /**
+     * @brief Bundle deletion status reports are requested.
+     */
+    bool deletion_status_req; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle delivery status reports are requested.
+     */
+    bool delivery_status_req; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle forwarding status reports are requested.
+     */
+    bool forwarding_status_req; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle reception status reports are requested.
+     */
+    bool reception_status_req; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Status time is requested in all status reports.
+     */
+    bool statusTimeRequested; /* 1   bits/1   bytes */
+
+    /**
+     * @brief User application acknowledgement is requested.
+     */
+    bool acknowledgementRequested; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle must not be fragmented.
+     */
+    bool mustNotFragment; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Payload is an administrative record.
+     */
+    bool isAdminRecord; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle is a fragment.
+     */
+    bool isFragment; /* 1   bits/1   bytes */
+} bp_bundle_processing_control_flags_t;
+
+typedef struct bp_block_processing_flags
+{
+
+    /**
+     * @brief Block must be removed from bundle if it can't be processed.
+     */
+    bool must_remove; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Bundle must be deleted if block can't be processed.
+     */
+    bool must_delete; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Transmission of a status report is requested if block can't be processed.
+     */
+    bool xmit_status; /* 1   bits/1   bytes */
+
+    /**
+     * @brief Block must be replicated in every fragment.
+     */
+    bool must_replicate; /* 1   bits/1   bytes */
+
+} bp_block_processing_flags_t;
+
+typedef bp_integer_t bp_lifetime_t;
+typedef bp_integer_t bp_adu_length_t;
+
+typedef union bp_endpointid_ssp
+{
+    bp_ipn_uri_ssp_t ipn; /* present if scheme == bp_endpointid_scheme_ipn */
+} bp_endpointid_ssp_t;
+
+typedef struct bp_endpointid_buffer
+{
+    bp_endpointid_scheme_t scheme; /* always present, indicates which union field is valid */
+    bp_endpointid_ssp_t    ssp;
+} bp_endpointid_buffer_t;
+
+typedef struct bp_primary_block
+{
+    uint8_t                              version;
+    bp_bundle_processing_control_flags_t controlFlags;
+    bp_crctype_t                         crctype; /* always present, indicates which CRC field is valid */
+    bp_endpointid_buffer_t               destinationEID;
+    bp_endpointid_buffer_t               sourceID;
+    bp_endpointid_buffer_t               reportEID;
+    bp_creation_timestamp_t              creationTimeStamp;
+    bp_lifetime_t                        lifetime;
+    bp_adu_length_t                      fragmentOffset;
+    bp_adu_length_t                      totalADUlength;
+    bp_crcval_t                          crcval;
+
+} bp_primary_block_t;
+
+typedef struct bp_canonical_bundle_block
+{
+    bp_blocktype_t              blockType;
+    bp_blocknum_t               blockNum;
+    bp_crctype_t                crctype; /* always present, indicates which CRC field is valid */
+    bp_block_processing_flags_t processingControlFlags;
+
+    bp_crcval_t crcval;
+
+} bp_canonical_bundle_block_t;
+
+typedef struct bp_previous_node_block
+{
+    bp_endpointid_buffer_t nodeId;
+} bp_previous_node_block_t;
+
+typedef struct bp_bundle_age_block
+{
+    bp_dtntime_t age;
+} bp_bundle_age_block_t;
+
+typedef struct bp_hop_count_block
+{
+    bp_integer_t hopLimit;
+    bp_integer_t hopCount;
+} bp_hop_count_block_t;
+
+typedef union bp_canonical_block_data
+{
+    bp_previous_node_block_t previous_node_block;
+    bp_bundle_age_block_t    age_block;
+    bp_hop_count_block_t     hop_count_block;
+} bp_canonical_block_data_t;
+
+typedef struct bp_canonical_block_buffer
+{
+    bp_canonical_bundle_block_t canonical_block; /* always present */
+    bp_canonical_block_data_t   data;            /* variable data field, depends on type */
+} bp_canonical_block_buffer_t;
+
+#endif /* v7_types_h */


### PR DESCRIPTION
Defines the BPv7 structures and adds a memory pool / RAM storage service specifically for BPv7.  This also adds a new CMake option to build the new v7 code, although it is not actually hooked into bplib at this time.