### PR TITLE
Fix #81, update license to Apache

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/app/bpio.h
+++ b/app/bpio.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bpio.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef __bpio_h__
-#define __bpio_h__
+#ifndef BPIO_H
+#define BPIO_H
 
 /*************************************************************************
  * Includes
@@ -50,4 +53,4 @@ typedef struct
     int        dacs_port;
 } thread_parm_t;
 
-#endif /* __bpio_h__ */
+#endif /* BPIO_H */

--- a/app/bprecv.c
+++ b/app/bprecv.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: bprecv.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /*************************************************************************
  * Includes

--- a/app/bpsend.c
+++ b/app/bpsend.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: bpsend.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /*************************************************************************
  * Includes

--- a/app/sock.c
+++ b/app/sock.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: bpsock.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /*************************************************************************
  * Includes

--- a/app/sock.h
+++ b/app/sock.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bpsock.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bpsock_
-#define _bpsock_
+#ifndef SOCK_H
+#define SOCK_H
 
 /******************************************************************************
  * Defines
@@ -38,4 +41,4 @@ int  socksend(int fd, const void *buf, int size, int timeout);
 int  sockrecv(int fd, void *buf, int size, int timeout);
 void sockclose(int fd);
 
-#endif /* _bpsock_ */
+#endif /* SOCK_H */

--- a/binding/lua/lua_bplib.c
+++ b/binding/lua/lua_bplib.c
@@ -1,20 +1,22 @@
-
-/************************************************************************
- * File: lua_bplib.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/binding/lua/lua_bplib.h
+++ b/binding/lua/lua_bplib.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: lua_bplib.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _lua_bplib_h_
-#define _lua_bplib_h_
+ */
+
+#ifndef LUA_BPLIB_H
+#define LUA_BPLIB_H
 
 /******************************************************************************
  INCLUDES
@@ -29,4 +33,4 @@
 
 int luaopen_bplib(lua_State *L);
 
-#endif /* _lua_bplib_h_ */
+#endif /* LUA_BPLIB_H */

--- a/common/cbuf.c
+++ b/common/cbuf.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: cbuf.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/common/cbuf.h
+++ b/common/cbuf.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: cbuf.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _cbuf_h_
-#define _cbuf_h_
+ */
+
+#ifndef CBUF_H
+#define CBUF_H
 
 /******************************************************************************
  INCLUDES
@@ -50,4 +54,4 @@ int cbuf_remove(cbuf_t *cbuf, bp_val_t cid, bp_active_bundle_t *bundle);
 int cbuf_available(cbuf_t *cbuf, bp_val_t cid);
 int cbuf_count(cbuf_t *cbuf);
 
-#endif /* _cbuf_h_ */
+#endif /* CBUF_H */

--- a/common/crc.c
+++ b/common/crc.c
@@ -1,20 +1,22 @@
-/************************************************************************
- * File: crc.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES
@@ -117,7 +119,7 @@ bplib_crc_parameters_t BPLIB_CRC32_CASTAGNOLI = {
  ******************************************************************************/
 
 static uint16_t bplib_crc_generic16_impl(const uint8_t *input_table, const uint16_t *xor_table, uint16_t crc,
-                                            const uint8_t *ptr, size_t size)
+                                         const uint8_t *ptr, size_t size)
 {
     while (size > 0)
     {
@@ -130,7 +132,7 @@ static uint16_t bplib_crc_generic16_impl(const uint8_t *input_table, const uint1
 }
 
 static uint32_t bplib_crc_generic32_impl(const uint8_t *input_table, const uint32_t *xor_table, uint32_t crc,
-                                            const uint8_t *ptr, size_t size)
+                                         const uint8_t *ptr, size_t size)
 {
     while (size > 0)
     {
@@ -159,7 +161,7 @@ bp_crcval_t bplib_crc_digest_CRC32_CASTAGNOLI(bp_crcval_t crc, const void *ptr, 
 
 bp_crcval_t bplib_precompute_crc_byte(uint8_t width, uint8_t byte, bp_crcval_t polynomial)
 {
-    uint8_t mask;
+    uint8_t     mask;
     bp_crcval_t next_bit;
     bp_crcval_t crcval;
 
@@ -198,8 +200,8 @@ uint8_t bplib_precompute_reflection(uint8_t byte)
     uint8_t input;
     uint8_t result;
 
-    mask = 0xFF;
-    input = byte;
+    mask   = 0xFF;
+    input  = byte;
     result = 0;
     while (mask != 0)
     {
@@ -227,7 +229,7 @@ uint8_t bplib_precompute_reflection(uint8_t byte)
  *-------------------------------------------------------------------------------------*/
 void bplib_crc_init(void)
 {
-    uint8_t  byte;
+    uint8_t byte;
 
     byte = 0;
     do
@@ -253,7 +255,7 @@ const char *bplib_crc_get_name(bplib_crc_parameters_t *params)
     return params->name;
 }
 
-uint8_t     bplib_crc_get_width(bplib_crc_parameters_t *params)
+uint8_t bplib_crc_get_width(bplib_crc_parameters_t *params)
 {
     return params->length;
 }
@@ -278,7 +280,7 @@ bp_crcval_t bplib_crc_finalize(bplib_crc_parameters_t *params, bp_crcval_t crc)
         crc_final = 0;
 
         /* Reflect 8 bits at a time while possible */
-        i  = params->length;
+        i = params->length;
         while (i >= 8)
         {
             crc_final <<= 8;
@@ -304,7 +306,7 @@ bp_crcval_t bplib_crc_finalize(bplib_crc_parameters_t *params, bp_crcval_t crc)
     crc_final ^= params->final_xor;
 
     /* Return the CRC but mask out the significant bits */
-    if(params->length < 32)
+    if (params->length < 32)
     {
         crc_final &= ((bp_crcval_t)1 << params->length) - 1;
     }

--- a/common/crc.h
+++ b/common/crc.h
@@ -1,23 +1,25 @@
-/************************************************************************
- * File: crc.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _crc_h_
-#define _crc_h_
+#ifndef CRC_H
+#define CRC_H
 
 /******************************************************************************
  INCLUDES
@@ -55,7 +57,7 @@ extern bplib_crc_parameters_t BPLIB_CRC32_CASTAGNOLI;
  PROTOTYPES
  ******************************************************************************/
 
-void    bplib_crc_init(void);
+void bplib_crc_init(void);
 
 const char *bplib_crc_get_name(bplib_crc_parameters_t *params);
 uint8_t     bplib_crc_get_width(bplib_crc_parameters_t *params);
@@ -65,4 +67,4 @@ bp_crcval_t bplib_crc_finalize(bplib_crc_parameters_t *params, bp_crcval_t crc);
 
 bp_crcval_t bplib_crc_get(const uint8_t *data, const uint32_t length, bplib_crc_parameters_t *params);
 
-#endif /* _crc_h_ */
+#endif /* CRC_H */

--- a/common/lrc.c
+++ b/common/lrc.c
@@ -1,22 +1,22 @@
-/************************************************************************
- * File: lrc.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * Notes:
- *  This module implements a longitudinal redundancy check using 2 bytes of
- *  check codes for every 7 bytes of data.
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/common/lrc.h
+++ b/common/lrc.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: lrc.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _lrc_h_
-#define _lrc_h_
+ */
+
+#ifndef LRC_H
+#define LRC_H
 
 /******************************************************************************
  INCLUDES
@@ -32,4 +36,4 @@ void lrc_uninit(void);
 void lrc_encode(uint8_t *frame_buffer, int data_size);
 int  lrc_decode(uint8_t *frame_buffer, int data_size);
 
-#endif /* _lrc_h_ */
+#endif /* LRC_H */

--- a/common/rb_tree.c
+++ b/common/rb_tree.c
@@ -1,20 +1,22 @@
-/************************************************************************
- * File: rb_tree.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/common/rb_tree.h
+++ b/common/rb_tree.h
@@ -1,23 +1,25 @@
-/************************************************************************
- * File: rb_tree.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _rb_tree_h_
-#define _rb_tree_h_
+#ifndef RB_TREE_H
+#define RB_TREE_H
 
 /******************************************************************************
  INCLUDES
@@ -91,4 +93,4 @@ int rb_tree_get_next(
     rb_tree_t *tree, rb_range_t *range, bool should_pop,
     bool should_rebalance); /* Gets the next range in order in the rb_tree_t and increments the iterator. */
 
-#endif /* _rb_tree_h_ */
+#endif /* RB_TREE_H */

--- a/common/rh_hash.c
+++ b/common/rh_hash.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: rh_hash.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/common/rh_hash.h
+++ b/common/rh_hash.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: rh_hash.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _rh_hash_h_
-#define _rh_hash_h_
+ */
+
+#ifndef RH_HASH_H
+#define RH_HASH_H
 
 /******************************************************************************
  INCLUDES
@@ -58,4 +62,4 @@ int rh_hash_remove(rh_hash_t *rh_hash, bp_val_t cid, bp_active_bundle_t *bundle)
 int rh_hash_available(rh_hash_t *rh_hash, bp_val_t cid);
 int rh_hash_count(rh_hash_t *rh_hash);
 
-#endif /* _rh_hash_h_ */
+#endif /* RH_HASH_H */

--- a/inc/bplib.h
+++ b/inc/bplib.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bplib.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_h_
-#define _bplib_h_
+#ifndef BPLIB_H
+#define BPLIB_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -269,4 +272,4 @@ int bplib_attrinit(bp_attr_t *attributes);
 } // extern "C"
 #endif
 
-#endif /* _bplib_h_ */
+#endif /* BPLIB_H */

--- a/inc/bplib_api_types.h
+++ b/inc/bplib_api_types.h
@@ -1,18 +1,25 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-#ifndef _bplib_api_types_h_
-#define _bplib_api_types_h_
+#ifndef BPLIB_API_TYPES_H
+#define BPLIB_API_TYPES_H
 
 /* BP types are based on C99 standard types */
 #include <stdint.h>
@@ -175,4 +182,4 @@ static inline bp_handle_t bp_handle_from_serial(int hv, bp_handle_t base)
 } // extern "C"
 #endif
 
-#endif /* _bplib_h_ */
+#endif /* BPLIB_API_TYPES_H */

--- a/inc/bplib_flash_sim.h
+++ b/inc/bplib_flash_sim.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bplib_flash_sim.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_flash_sim_h_
-#define _bplib_flash_sim_h_
+#ifndef BPLIB_FLASH_SIM_H
+#define BPLIB_FLASH_SIM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,4 +57,4 @@ int bplib_flash_sim_block_mark_bad(bp_flash_index_t block);
 } // extern "C"
 #endif
 
-#endif /* _bplib_flash_sim_h_ */
+#endif /* BPLIB_FLASH_SIM_H */

--- a/inc/bplib_os.h
+++ b/inc/bplib_os.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bplib_os.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_os_h_
-#define _bplib_os_h_
+#ifndef BPLIB_OS_H
+#define BPLIB_OS_H
 
 /******************************************************************************
  INCLUDES
@@ -78,4 +81,4 @@ void        bplib_os_free(void *ptr);
 size_t      bplib_os_memused(void);
 size_t      bplib_os_memhigh(void);
 
-#endif /* _bplib_os_h_ */
+#endif /* BPLIB_OS_H */

--- a/inc/bplib_store_file.h
+++ b/inc/bplib_store_file.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bplib_store_file.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_store_file_h_
-#define _bplib_store_file_h_
+#ifndef BPLIB_STORE_FILE_H
+#define BPLIB_STORE_FILE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,4 +75,4 @@ int bplib_store_file_getcount(bp_handle_t h);
 } // extern "C"
 #endif
 
-#endif /* _bplib_store_file_h_ */
+#endif /* BPLIB_STORE_FILE_H */

--- a/inc/bplib_store_flash.h
+++ b/inc/bplib_store_flash.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: flash_store.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_store_flash_h_
-#define _bplib_store_flash_h_
+#ifndef BPLIB_STORE_FLASH_H
+#define BPLIB_STORE_FLASH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,4 +128,4 @@ int bplib_store_flash_getcount(bp_handle_t h);
 } // extern "C"
 #endif
 
-#endif /* _bplib_store_flash_h_ */
+#endif /* BPLIB_STORE_FLASH_H */

--- a/inc/bplib_store_ram.h
+++ b/inc/bplib_store_ram.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bplib_store_ram.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bplib_store_ram_h_
-#define _bplib_store_ram_h_
+#ifndef BPLIB_STORE_RAM_H
+#define BPLIB_STORE_RAM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,4 +54,4 @@ int bplib_store_ram_getcount(bp_handle_t h);
 } // extern "C"
 #endif
 
-#endif /* _bplib_store_ram_h_ */
+#endif /* BPLIB_STORE_RAM_H */

--- a/lib/bplib.c
+++ b/lib/bplib.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: bplib.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/lib/bundle_types.h
+++ b/lib/bundle_types.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bundle_types.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bundle_types_h_
-#define _bundle_types_h_
+#ifndef BUNDLE_TYPES_H
+#define BUNDLE_TYPES_H
 
 /******************************************************************************
  INCLUDES
@@ -103,4 +106,4 @@ typedef struct
     void            *blocks;     /* populated in initialization function */
 } bp_bundle_t;
 
-#endif /* _bundle_types_h_ */
+#endif /* BUNDLE_TYPES_H */

--- a/os/cfe.c
+++ b/os/cfe.c
@@ -1,25 +1,22 @@
-/************************************************************************
- * File: bplib_os_cfe.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
- *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/os/posix.c
+++ b/os/posix.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: posix.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/store/file.c
+++ b/store/file.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: file.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/store/file_cfe.c
+++ b/store/file_cfe.c
@@ -1,10 +1,22 @@
-/************************************************************************
- * File: bplib_store_file_custom.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *************************************************************************/
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /******************************************************************************
  INCLUDES

--- a/store/file_cfe.h
+++ b/store/file_cfe.h
@@ -1,13 +1,25 @@
-/************************************************************************
- * File: bplib_store_file_custom.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *************************************************************************/
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-#ifndef _bplib_store_file_custom_h_
-#define _bplib_store_file_custom_h_
+#ifndef FILE_CFE_H
+#define FILE_CFE_H
 
 /******************************************************************************
  INCLUDES
@@ -35,4 +47,4 @@ size_t    bp_cfe_fwrite(const void *ptr, size_t size, size_t count, bp_file_t st
 int       bp_cfe_fseek(bp_file_t stream, long offset, int origin);
 int       bp_cfe_fflush(bp_file_t stream);
 
-#endif /* _bplib_store_file_custom_h_ */
+#endif /* FILE_CFE_H */

--- a/store/flash.c
+++ b/store/flash.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: flash.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/store/flash_sim.c
+++ b/store/flash_sim.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: flash_sim.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/store/ram.c
+++ b/store/ram.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: ram.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  * INCLUDES

--- a/unittest/unittest.c
+++ b/unittest/unittest.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: unittest.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/unittest/unittest.h
+++ b/unittest/unittest.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: unittest.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _unittest_h_
-#define _unittest_h_
+ */
+
+#ifndef UNITTEST_H
+#define UNITTEST_H
 
 /******************************************************************************
  EXPORTED FUNCTIONS
@@ -26,4 +30,4 @@ int bplib_unittest_rb_tree(void);
 int bplib_unittest_rh_hash(void);
 int bplib_unittest_flash(void);
 
-#endif /* _unittest_h_ */
+#endif /* UNITTEST_H */

--- a/unittest/ut_assert.c
+++ b/unittest/ut_assert.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: ut_assert.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/unittest/ut_assert.h
+++ b/unittest/ut_assert.h
@@ -1,21 +1,25 @@
-/************************************************************************
- * File: ut_assert.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
-#ifndef _ut_assert_h_
-#define _ut_assert_h_
+ */
+
+#ifndef UT_ASSERT_H
+#define UT_ASSERT_H
 
 /******************************************************************************
  INCLUDES
@@ -40,4 +44,4 @@ void ut_reset(void);
 bool _ut_assert(bool e, const char *file, int line, const char *fmt, ...);
 int  ut_failures(void);
 
-#endif /* _ut_assert_h_ */
+#endif /* UT_ASSERT_H */

--- a/unittest/ut_crc.c
+++ b/unittest/ut_crc.c
@@ -1,20 +1,22 @@
-/************************************************************************
- * File: ut_crc.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/unittest/ut_flash.c
+++ b/unittest/ut_flash.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: ut_flash.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/unittest/ut_rb_tree.c
+++ b/unittest/ut_rb_tree.c
@@ -1,20 +1,22 @@
-/************************************************************************
- * File: ut_crc.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Alexander Meade, Code 582 NASA GSFC
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/unittest/ut_rh_hash.c
+++ b/unittest/ut_rh_hash.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: ut_rh_hash.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/bib.c
+++ b/v6/bib.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: bib.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES
@@ -26,7 +29,6 @@
 #include "crc.h"
 #include "v6.h"
 #include "bib.h"
-
 
 /******************************************************************************
  STATIC FUNCTIONS

--- a/v6/bib.h
+++ b/v6/bib.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: bib.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _bib_h_
-#define _bib_h_
+#ifndef BIB_H
+#define BIB_H
 
 /******************************************************************************
  INCLUDES
@@ -60,4 +63,4 @@ int bib_write(void *block, int size, bp_blk_bib_t *bib, bool update_indices, uin
 int bib_update(void *block, int size, const void *payload, int payload_size, bp_blk_bib_t *bib, uint32_t *flags);
 int bib_verify(const void *payload, int payload_size, bp_blk_bib_t *bib, uint32_t *flags);
 
-#endif /* _bib_h_ */
+#endif /* BIB_H */

--- a/v6/cteb.c
+++ b/v6/cteb.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: cteb.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/cteb.h
+++ b/v6/cteb.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: cteb.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _cteb_h_
-#define _cteb_h_
+#ifndef CTEB_H
+#define CTEB_H
 
 /******************************************************************************
  INCLUDES
@@ -46,4 +49,4 @@ typedef struct
 int cteb_read(const void *block, int size, bp_blk_cteb_t *cteb, bool update_indices, uint32_t *flags);
 int cteb_write(void *block, int size, bp_blk_cteb_t *cteb, bool update_indices, uint32_t *flags);
 
-#endif /* _cteb_h_ */
+#endif /* CTEB_H */

--- a/v6/dacs.c
+++ b/v6/dacs.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: dacs.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/dacs.h
+++ b/v6/dacs.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: dacs.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _dacs_h_
-#define _dacs_h_
+#ifndef DACS_H
+#define DACS_H
 
 /******************************************************************************
  INCLUDES
@@ -33,4 +36,4 @@
 int dacs_write(uint8_t *rec, int size, int max_fills_per_dacs, rb_tree_t *tree, uint32_t *flags);
 int dacs_read(const uint8_t *rec, int rec_size, int *num_acks, bp_delete_func_t ack, void *ack_parm, uint32_t *flags);
 
-#endif /* _dacs_h_ */
+#endif /* DACS_H */

--- a/v6/pay.c
+++ b/v6/pay.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: pay.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/pay.h
+++ b/v6/pay.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: pay.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _pay_h_
-#define _pay_h_
+#ifndef PAY_H
+#define PAY_H
 
 /******************************************************************************
  INCLUDES
@@ -44,4 +47,4 @@ typedef struct
 int pay_read(const void *block, int size, bp_blk_pay_t *pay, bool update_indices, uint32_t *flags);
 int pay_write(void *block, int size, bp_blk_pay_t *pay, bool update_indices, uint32_t *flags);
 
-#endif /* _pay_h_ */
+#endif /* PAY_H */

--- a/v6/pri.c
+++ b/v6/pri.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: pri.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/pri.h
+++ b/v6/pri.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: pri.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _pri_h_
-#define _pri_h_
+#ifndef PRI_H
+#define PRI_H
 
 /******************************************************************************
  INCLUDES
@@ -66,4 +69,4 @@ typedef struct
 int pri_read(const void *block, int size, bp_blk_pri_t *pri, bool update_indices, uint32_t *flags);
 int pri_write(void *block, int size, bp_blk_pri_t *pri, bool update_indices, uint32_t *flags);
 
-#endif /* _pri_h_ */
+#endif /* PRI_H */

--- a/v6/sdnv.c
+++ b/v6/sdnv.c
@@ -1,26 +1,22 @@
-/************************************************************************
- * File: sdnv.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * Design Notes :
- *   1. The read routines make no assumptions on fixed lengths but there still
- *      needs to be an assumption made as to the size of the variable to hold
- *      the resulting read.  Therefore if the requested variable size is too
- *      small to hold the read value, an OVERFLOW flag is set.
- *   2. The write routines do assume a fixed length and will write an SDNV that
- *      is always the size specified regardless of the value passed to it.
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/sdnv.h
+++ b/v6/sdnv.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: sdnv.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _sdnv_h_
-#define _sdnv_h_
+#ifndef SDNV_H
+#define SDNV_H
 
 /******************************************************************************
  INCLUDES
@@ -33,4 +36,4 @@ int  sdnv_read(const uint8_t *block, int size, bp_field_t *sdnv, uint32_t *flags
 int  sdnv_write(uint8_t *block, int size, bp_field_t sdnv, uint32_t *flags);
 void sdnv_mask(bp_field_t *sdnv);
 
-#endif /* _sdnv_h_ */
+#endif /* SDNV_H */

--- a/v6/v6.c
+++ b/v6/v6.c
@@ -1,19 +1,22 @@
-/************************************************************************
- * File: blocks.c
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v6/v6.h
+++ b/v6/v6.h
@@ -1,22 +1,25 @@
-/************************************************************************
- * File: v6.h
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Maintainer(s):
- *  Joe-Paul Swinski, Code 582 NASA GSFC
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- *************************************************************************/
+ */
 
-#ifndef _v6_h_
-#define _v6_h_
+#ifndef V6_H
+#define V6_H
 
 /******************************************************************************
  INCLUDES
@@ -98,4 +101,4 @@ int v6_is_expired(bp_bundle_t *bundle, unsigned long sysnow, unsigned long exprt
 int v6_routeinfo(const void *bundle, int size, bp_route_t *route);
 int v6_display(const void *bundle, int size, uint32_t *flags);
 
-#endif /* _v6_h_ */
+#endif /* V6_H */

--- a/v7/v7_codec.c
+++ b/v7/v7_codec.c
@@ -1,15 +1,22 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v7/v7_codec.h
+++ b/v7/v7_codec.h
@@ -1,18 +1,25 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-#ifndef v7_codec_h
-#define v7_codec_h
+#ifndef V7_CODEC_H
+#define V7_CODEC_H
 
 /******************************************************************************
  INCLUDES
@@ -42,4 +49,4 @@ int v7_block_encode_pri(mpool_t *pool, mpool_cache_primary_block_t *cpb);
 int v7_block_encode_pay(mpool_t *pool, mpool_cache_canonical_block_t *ccb, const void *data_ptr, size_t data_size);
 int v7_block_encode_canonical(mpool_t *pool, mpool_cache_canonical_block_t *ccb);
 
-#endif
+#endif /* V7_CODEC_H */

--- a/v7/v7_mpool.c
+++ b/v7/v7_mpool.c
@@ -1,15 +1,22 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 /******************************************************************************
  INCLUDES

--- a/v7/v7_mpool.h
+++ b/v7/v7_mpool.h
@@ -1,18 +1,25 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2019 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-#ifndef bplib_mpool_h
-#define bplib_mpool_h
+#ifndef V7_MPOOL_H
+#define V7_MPOOL_H
 
 #include <string.h>
 
@@ -261,4 +268,4 @@ size_t mpool_copy_block_chain(mpool_cache_block_t *list, void *out_ptr, size_t m
 
 mpool_t *mpool_create(void *pool_mem, size_t pool_size);
 
-#endif
+#endif /* V7_MPOOL_H */

--- a/v7/v7_types.h
+++ b/v7/v7_types.h
@@ -1,18 +1,25 @@
-/************************************************************************
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
  *
- *  Copyright 2022 United States Government as represented by the
- *  Administrator of the National Aeronautics and Space Administration.
- *  All Other Rights Reserved.
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This software was created at NASA's Goddard Space Flight Center.
- *  This software is governed by the NASA Open Source Agreement and may be
- *  used, distributed and modified only pursuant to the terms of that
- *  agreement.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *************************************************************************/
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-#ifndef v7_types_h
-#define v7_types_h
+#ifndef V7_TYPES_H
+#define V7_TYPES_H
 
 /******************************************************************************
  INCLUDES
@@ -247,4 +254,4 @@ typedef struct bp_canonical_block_buffer
     bp_canonical_block_data_t   data;            /* variable data field, depends on type */
 } bp_canonical_block_buffer_t;
 
-#endif /* v7_types_h */
+#endif /* V7_TYPES_H */


### PR DESCRIPTION
Update source code boilerplate comments and LICENSE file to reflect updated Apache-2.0 release.

This also updates the `#include` protection tags, as the tool used to do the boilerplate updates also did this change (this brings consistency with the CFE coding standard for this, so it is not a bad thing).