### PR TITLE
Fix #92, Implement blocktype registration API

### DIFF
--- a/common/v7_rbtree.c
+++ b/common/v7_rbtree.c
@@ -282,8 +282,7 @@ BP_LOCAL_SCOPE void remove_from_parent(bplib_rbt_root_t *tree, bplib_rbt_link_t 
  * @param parent Pointer to the current parent which should become child
  * @param child  Pointer to the current child which should become parent
  */
-BP_LOCAL_SCOPE void swap_parent_and_child(bplib_rbt_root_t *tree, bplib_rbt_link_t *parent,
-                                          bplib_rbt_link_t *child)
+BP_LOCAL_SCOPE void swap_parent_and_child(bplib_rbt_root_t *tree, bplib_rbt_link_t *parent, bplib_rbt_link_t *child)
 {
     bplib_rbt_link_t **grandparent_ref;
     bplib_rbt_link_t  *saved_left;
@@ -422,9 +421,9 @@ BP_LOCAL_SCOPE int do_insert_as_leaf(bplib_rbt_root_t *tree, bplib_rbt_link_t *n
     bplib_rbt_link_t  *curr_ptr;
     bplib_rbt_link_t **ref_ptr;
     bplib_rbt_link_t  *parent_ptr;
-    bp_val_t                 curr_key_value;
-    bp_val_t                 insert_key_value;
-    int                      status;
+    bp_val_t           curr_key_value;
+    bp_val_t           insert_key_value;
+    int                status;
 
     status           = BP_ERROR;
     parent_ptr       = NULL;
@@ -481,8 +480,8 @@ BP_LOCAL_SCOPE void do_insert_rebalance(bplib_rbt_root_t *tree, bplib_rbt_link_t
     bplib_rbt_link_t *parent;
     bplib_rbt_link_t *uncle;
     bplib_rbt_link_t *node;
-    bool                    node_is_left_side;
-    bool                    parent_is_left_side;
+    bool              node_is_left_side;
+    bool              parent_is_left_side;
     enum
     {
         insert_case_undefined,        /**< invalid/undefined/unknown tree state */
@@ -797,7 +796,7 @@ BP_LOCAL_SCOPE void do_delete_rebalance(bplib_rbt_root_t *tree, bplib_rbt_link_t
     bplib_rbt_link_t *distant_nephew;
     bplib_rbt_link_t *parent;
     bplib_rbt_link_t *node;
-    bool                    node_is_left_side;
+    bool              node_is_left_side;
     enum
     {
         delete_case_undefined,        /**< invalid/undefined/unknown tree state */
@@ -1025,6 +1024,11 @@ BP_LOCAL_SCOPE void do_delete_rebalance(bplib_rbt_root_t *tree, bplib_rbt_link_t
  EXPORTED FUNCTIONS
  ******************************************************************************/
 
+void bplib_rbt_init_root(bplib_rbt_root_t *tree)
+{
+    memset(tree, 0, sizeof(*tree));
+}
+
 /*--------------------------------------------------------------------------------------
  * rb_tree_binary_search - Searches a rb_tree for a node containing a given value.
  *
@@ -1036,7 +1040,7 @@ BP_LOCAL_SCOPE void do_delete_rebalance(bplib_rbt_root_t *tree, bplib_rbt_link_t
 bplib_rbt_link_t *bplib_rbt_search(bp_val_t search_key_value, const bplib_rbt_root_t *tree)
 {
     bplib_rbt_link_t *curr_ptr;
-    bp_val_t                curr_key_value;
+    bp_val_t          curr_key_value;
 
     curr_ptr = tree->root;
     while (curr_ptr != NULL)
@@ -1140,7 +1144,7 @@ int bplib_rbt_extract_node(bplib_rbt_root_t *tree, bplib_rbt_link_t *removed_nod
  *--------------------------------------------------------------------------------------*/
 int bplib_rbt_extract_value(bp_val_t value, bplib_rbt_root_t *tree, bplib_rbt_link_t **link_block)
 {
-    int                     status;
+    int               status;
     bplib_rbt_link_t *node;
 
     /* First do a normal search to find the node containing the value */
@@ -1174,7 +1178,7 @@ bool bplib_rbt_node_is_red(const bplib_rbt_link_t *node)
 int bplib_rbt_iter_next(bplib_rbt_iter_t *iter)
 {
     const bplib_rbt_link_t *next_pos;
-    bp_val_t                      last_val;
+    bp_val_t                last_val;
 
     next_pos = iter->position;
     if (next_pos != NULL)
@@ -1222,7 +1226,7 @@ int bplib_rbt_iter_next(bplib_rbt_iter_t *iter)
 int bplib_rbt_iter_prev(bplib_rbt_iter_t *iter)
 {
     const bplib_rbt_link_t *prev_pos;
-    bp_val_t                      last_val;
+    bp_val_t                last_val;
 
     prev_pos = iter->position;
     if (prev_pos != NULL)
@@ -1271,7 +1275,7 @@ const bplib_rbt_link_t *bplib_rbt_iter_find_closest(bp_val_t target_value, const
 {
     const bplib_rbt_link_t *prev_pos;
     const bplib_rbt_link_t *curr_pos;
-    bp_val_t                      curr_val;
+    bp_val_t                curr_val;
 
     prev_pos = NULL;
     curr_val = 0;

--- a/common/v7_rbtree.h
+++ b/common/v7_rbtree.h
@@ -40,19 +40,18 @@
  */
 typedef struct bplib_rbt_link
 {
-    bp_val_t key_value_and_color;
+    bp_val_t               key_value_and_color;
     struct bplib_rbt_link *left;
     struct bplib_rbt_link *right;
     struct bplib_rbt_link *parent;
 } bplib_rbt_link_t;
-
 
 /**
  * @brief Basic R-B tree parent structure
  */
 typedef struct bplib_rbt_root
 {
-    int                     black_height; /* debug facility */
+    int               black_height; /* debug facility */
     bplib_rbt_link_t *root;         /* The current root of the tree. This may change as rebalance occurs. */
 } bplib_rbt_root_t;
 
@@ -66,6 +65,17 @@ typedef struct bplib_rbt_iter
  ******************************************************************************/
 
 /* Red Black Tree API */
+
+/*--------------------------------------------------------------------------------------*/
+/**
+ * @brief Initializes a newly allocated tree root object
+ *
+ * The tree will be empty after this call.  This must only be invoked
+ * on new root objects, or else memory may be leaked.
+ *
+ * @param tree The tree object to initialize
+ */
+void bplib_rbt_init_root(bplib_rbt_root_t *tree);
 
 /*--------------------------------------------------------------------------------------*/
 /**

--- a/lib/v7_routing.c
+++ b/lib/v7_routing.c
@@ -31,8 +31,6 @@
 #include "v7_mpool_ref.h"
 #include "v7.h"
 
-#define BPLIB_ROUTING_SIGNATURE_BASE_INTF 0xe1ce32cf
-
 #define BPLIB_INTF_AVAILABLE_FLAGS (BPLIB_INTF_STATE_OPER_UP | BPLIB_INTF_STATE_ADMIN_UP)
 
 typedef struct bplib_routeentry

--- a/mpool/inc/v7_mpool_flows.h
+++ b/mpool/inc/v7_mpool_flows.h
@@ -61,7 +61,15 @@ struct bplib_mpool_flow
  */
 bplib_mpool_flow_t *bplib_mpool_flow_cast(bplib_mpool_block_t *cb);
 
-bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, size_t req_capacity);
+/**
+ * @brief Allocate a flow block
+ *
+ * @param pool
+ * @param magic_number
+ * @param init_arg Opaque pointer passed to initializer (may be NULL)
+ * @return bplib_mpool_block_t*
+ */
+bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg);
 
 /**
  * @brief Append a single bundle to the given queue (flow)

--- a/mpool/inc/v7_mpool_ref.h
+++ b/mpool/inc/v7_mpool_ref.h
@@ -93,11 +93,10 @@ void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr);
  *
  * @param pool
  * @param blk
- * @param notify_on_discard
- * @param notify_arg
+ * @param init_arg Opaque pointer to pass to initializer (may be NULL)
  * @return bplib_mpool_block_t*
  */
 bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_t *pool, bplib_mpool_ref_t refptr, uint32_t magic_number,
-                                                bplib_mpool_callback_func_t notify_on_discard, void *notify_arg);
+                                                void *init_arg);
 
 #endif /* V7_MPOOL_REF_H */

--- a/mpool/src/v7_mpool_bblocks.c
+++ b/mpool/src/v7_mpool_bblocks.c
@@ -34,9 +34,11 @@
 #include "v7_types.h"
 #include "v7_mpool_internal.h"
 
-#define MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE   0x9bd24f2c
-#define MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE 0xd4802976
-#define MPOOL_CACHE_CBOR_DATA_SIGNATURE       0x6b243e33
+/* TBD: These are all base types so they do not really need to have a unique sig */
+/* Using 0 allows the default API to be used (no-op on create/delete). */
+#define MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE   0 /*0x9bd24f2c*/
+#define MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE 0 /*0xd4802976*/
+#define MPOOL_CACHE_CBOR_DATA_SIGNATURE       0 /*0x6b243e33*/
 
 /*----------------------------------------------------------------
  *
@@ -109,12 +111,6 @@ void bplib_mpool_bblock_primary_init(bplib_mpool_bblock_primary_t *pblk)
 {
     bplib_mpool_init_list_head(&pblk->cblock_list);
     bplib_mpool_init_list_head(&pblk->chunk_list);
-
-    /* wipe the logical content to be sure no stale data exists */
-    memset(&pblk->delivery_data, 0, sizeof(pblk->delivery_data));
-    memset(&pblk->pri_logical_data, 0, sizeof(pblk->pri_logical_data));
-    pblk->bundle_encode_size_cache = 0;
-    pblk->block_encode_size_cache  = 0;
 }
 
 /*----------------------------------------------------------------
@@ -125,11 +121,6 @@ void bplib_mpool_bblock_primary_init(bplib_mpool_bblock_primary_t *pblk)
 void bplib_mpool_bblock_canonical_init(bplib_mpool_bblock_canonical_t *cblk)
 {
     bplib_mpool_init_list_head(&cblk->chunk_list);
-
-    /* wipe the logical content to be sure no stale data exists */
-    memset(&cblk->canonical_logical_data, 0, sizeof(cblk->canonical_logical_data));
-    bplib_mpool_bblock_canonical_set_content_position(cblk, 0, 0);
-    cblk->block_encode_size_cache = 0;
 }
 
 /*----------------------------------------------------------------
@@ -139,7 +130,8 @@ void bplib_mpool_bblock_canonical_init(bplib_mpool_bblock_canonical_t *cblk)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
 {
-    return bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary, MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE);
+    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary,
+                                                                   MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE, NULL);
 }
 
 /*----------------------------------------------------------------
@@ -149,8 +141,8 @@ bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool)
 {
-    return bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical,
-                                            MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE);
+    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical,
+                                                                   MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE, NULL);
 }
 
 /*----------------------------------------------------------------
@@ -160,7 +152,8 @@ bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_cbor_alloc(bplib_mpool_t *pool)
 {
-    return bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_cbor_data, MPOOL_CACHE_CBOR_DATA_SIGNATURE);
+    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_cbor_data,
+                                                                   MPOOL_CACHE_CBOR_DATA_SIGNATURE, NULL);
 }
 
 /*----------------------------------------------------------------

--- a/mpool/src/v7_mpool_flows.c
+++ b/mpool/src/v7_mpool_flows.c
@@ -40,10 +40,7 @@
  *-----------------------------------------------------------------*/
 void bplib_mpool_subq_init(bplib_mpool_subq_t *qblk)
 {
-    /* clear the basic block, which zeros all stats */
-    memset(qblk, 0, sizeof(*qblk));
-
-    /* now init the link structs */
+    /* init the link structs */
     bplib_mpool_init_list_head(&qblk->block_listx);
 }
 
@@ -173,16 +170,10 @@ void bplib_mpool_flow_init(bplib_mpool_flow_t *fblk)
  * Function: bplib_mpool_flow_alloc
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, size_t req_capacity)
+bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg)
 {
-    static const size_t FLOW_AVAIL_CAPACITY = MPOOL_GET_BLOCK_USER_CAPACITY(flow);
-    if (req_capacity > FLOW_AVAIL_CAPACITY)
-    {
-        assert(0);
-        return NULL;
-    }
-
-    return bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number);
+    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number,
+                                                                   init_arg);
 }
 
 /*----------------------------------------------------------------

--- a/mpool/src/v7_mpool_ref.c
+++ b/mpool/src/v7_mpool_ref.c
@@ -90,24 +90,19 @@ bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_t *pool, bplib_mpool_block_
  *
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_t *pool, bplib_mpool_ref_t refptr, uint32_t magic_number,
-                                                bplib_mpool_callback_func_t notify_on_discard, void *notify_arg)
+                                                void *init_arg)
 {
-    bplib_mpool_block_content_t *content;
-    bplib_mpool_block_t         *rblk;
+    bplib_mpool_block_content_t *rblk;
 
-    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number);
+    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg);
     if (rblk == NULL)
     {
         return NULL;
     }
 
-    content = (bplib_mpool_block_content_t *)rblk;
+    rblk->u.ref.pref_target = bplib_mpool_ref_duplicate(refptr);
 
-    content->u.ref.pref_target       = bplib_mpool_ref_duplicate(refptr);
-    content->u.ref.notify_on_discard = notify_on_discard;
-    content->u.ref.notify_arg        = notify_arg;
-
-    return rblk;
+    return (bplib_mpool_block_t *)rblk;
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
Submodules can supply constructor/destructor routines for the service specific blocks via blocktype registration calls.  This removes some special code that was added for ref blocks to call a implementation function on recycle, because
that can now be done for any block type through a destructor.