### PR TITLE
Fix #94, implement basic custody transfer

### DIFF
--- a/common/v7_rbtree.c
+++ b/common/v7_rbtree.c
@@ -1030,6 +1030,29 @@ void bplib_rbt_init_root(bplib_rbt_root_t *tree)
 }
 
 /*--------------------------------------------------------------------------------------
+ * bplib_rbt_is_member - Checks if the given node is a member of the tree
+ *
+ * tree: A ptr to a bplib_rbt_root_t
+ * node: Memory block to test
+ * returns: true if the node is a member of the tree, false otherwise
+ *--------------------------------------------------------------------------------------*/
+bool bplib_rbt_is_member(const bplib_rbt_root_t *tree, const bplib_rbt_link_t *node)
+{
+    const bplib_rbt_link_t *root_node;
+
+    /* follow parent links until arrival at the tree root.  If a member
+     * of the tree, this should arrive at the same root node as pointed to
+     * in the "tree" structure */
+    root_node = node;
+    while (root_node->parent != NULL)
+    {
+        root_node = root_node->parent;
+    }
+
+    return (root_node == tree->root);
+}
+
+/*--------------------------------------------------------------------------------------
  * rb_tree_binary_search - Searches a rb_tree for a node containing a given value.
  *
  * tree: A ptr to a bplib_rbt_root_t to search. [INPUT]

--- a/common/v7_rbtree.h
+++ b/common/v7_rbtree.h
@@ -79,6 +79,17 @@ void bplib_rbt_init_root(bplib_rbt_root_t *tree);
 
 /*--------------------------------------------------------------------------------------*/
 /**
+ * @brief Checks if the given node is a member of the tree
+ *
+ * @param[in] tree   The tree to check
+ * @param[in] node   The node to check
+ * @return true if the node is currently a member of the specified tree
+ * @return false if the node is not currently a member of the specified tree
+ */
+bool bplib_rbt_is_member(const bplib_rbt_root_t *tree, const bplib_rbt_link_t *node);
+
+/*--------------------------------------------------------------------------------------*/
+/**
  * @brief Searches the Red-Black tree for a node matching a given value
  *
  * The tree is searched for a matching value, and if found, the pointer to that node

--- a/lib/v7_routing.c
+++ b/lib/v7_routing.c
@@ -822,6 +822,7 @@ void bplib_route_do_maintenance(bplib_routetbl_t *tbl)
     uint32_t              pos;
     bplib_intf_t         *ifp;
     bplib_generic_event_t poll_event;
+    int                   count;
 
     /* poll each interface, may move items to other queues based on time */
     poll_event.event_type = bplib_event_type_poll_interval;
@@ -836,14 +837,12 @@ void bplib_route_do_maintenance(bplib_routetbl_t *tbl)
     }
 
     /* now forward any bundles between interfaces, based on active flows */
-    while (true)
+    do
     {
         /* keep calling bplib_mpool_flow_process_active() until it returns 0 meaning no work was done */
-        if (bplib_mpool_flow_process_active(tbl->pool, bplib_route_forward_intf, tbl) <= 0)
-        {
-            break;
-        }
+        count = bplib_mpool_flow_process_active(tbl->pool, bplib_route_forward_intf, tbl);
     }
+    while (count > 0);
 
     /* now complete the recycle process for any blocks released by above */
     bplib_mpool_maintain(tbl->pool);

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -107,6 +107,18 @@ typedef void (*bplib_mpool_callback_func_t)(void *, bplib_mpool_block_t *);
  * Specifies functions for module-specific block operations,
  * including construction and destruction
  */
+typedef struct bplib_mpool_list_iter
+{
+    bplib_mpool_block_t *position;
+    bplib_mpool_block_t *pending_entry;
+} bplib_mpool_list_iter_t;
+
+/**
+ * @brief Blocktype API
+ *
+ * Specifies functions for module-specific block operations,
+ * including construction and destruction
+ */
 typedef struct bplib_mpool_blocktype_api
 {
     bplib_mpool_callback_func_t construct; /**< Initialize a newly-created block */
@@ -225,6 +237,52 @@ static inline bool bplib_mpool_is_any_content_node(const bplib_mpool_block_t *cb
 {
     return (cb->type >= bplib_mpool_blocktype_generic && cb->type < bplib_mpool_blocktype_max);
 }
+
+/* basic list iterators (forward or reverse) */
+
+/*--------------------------------------------------------------------------------------*/
+/**
+ * @brief Position an iterator at the first value in the list
+ *
+ * @param iter          The iterator object to position
+ * @returns integer status code
+ * @retval BP_SUCCESS if iterator is valid
+ */
+int bplib_mpool_list_iter_goto_first(const bplib_mpool_block_t *list, bplib_mpool_list_iter_t *iter);
+
+/*--------------------------------------------------------------------------------------*/
+/**
+ * @brief Position an iterator at the last value in the list
+ *
+ * @param iter          The iterator object to position
+ * @returns integer status code
+ * @retval BP_SUCCESS if iterator is valid
+ */
+int bplib_mpool_list_iter_goto_last(const bplib_mpool_block_t *list, bplib_mpool_list_iter_t *iter);
+
+/*--------------------------------------------------------------------------------------*/
+/**
+ * @brief Move an iterator forward by one step in the tree
+ *
+ * Sets the iterator to the immediate successor of the current node.
+ * This allows the caller to perform a ascending-order tree traversal.
+ *
+ * @param iter          The iterator object to move
+ * @retval BP_SUCCESS if iterator is valid
+ */
+int bplib_mpool_list_iter_forward(bplib_mpool_list_iter_t *iter);
+
+/*--------------------------------------------------------------------------------------*/
+/**
+ * @brief Move an iterator backward by one step in the tree
+ *
+ * Sets the iterator to the immediate predecessor of the current node.
+ * This allows the caller to perform a descending-order tree traversal.
+ *
+ * @param iter          The iterator object to move
+ * @retval BP_SUCCESS if iterator is valid
+ */
+int bplib_mpool_list_iter_reverse(bplib_mpool_list_iter_t *iter);
 
 /**
  * @brief Initialize a secondary link for block indexing purposes

--- a/mpool/inc/v7_mpool_bblocks.h
+++ b/mpool/inc/v7_mpool_bblocks.h
@@ -30,12 +30,14 @@ typedef struct bplib_mpool_bblock_tracking
 {
     bplib_policy_delivery_t delivery_policy;
     bp_handle_t             ingress_intf_id;
+    uint64_t                ingress_time;
     bp_handle_t             egress_intf_id;
+    uint64_t                egress_time;
     bp_handle_t             storage_intf_id;
     bp_sid_t                committed_storage_id;
-    uint64_t                local_retx_interval;
-    bp_dtntime_t            ingress_time;
-    bp_dtntime_t            egress_time;
+
+    /* JPHFIX: this is here for now, but really it belongs on the egress CLA intf based on its RTT */
+    uint64_t local_retx_interval;
 } bplib_mpool_bblock_tracking_t;
 
 struct bplib_mpool_bblock_primary
@@ -224,6 +226,15 @@ void bplib_mpool_bblock_cbor_append(bplib_mpool_block_t *head, bplib_mpool_block
  * @param ccb
  */
 void bplib_mpool_bblock_primary_append(bplib_mpool_bblock_primary_t *cpb, bplib_mpool_block_t *ccb);
+
+/**
+ * @brief Find a canonical block within the bundle
+ *
+ * @param cpb
+ * @param ccb
+ */
+bplib_mpool_block_t *bplib_mpool_bblock_primary_locate_canonical(bplib_mpool_bblock_primary_t *cpb,
+                                                                 bp_blocktype_t                block_type);
 
 /**
  * @brief Drop all encode data (CBOR) from a primary block

--- a/mpool/src/v7_mpool.c
+++ b/mpool/src/v7_mpool.c
@@ -422,6 +422,76 @@ void bplib_mpool_recycle_block(bplib_mpool_t *pool, bplib_mpool_block_t *blk)
 
 /*----------------------------------------------------------------
  *
+ * Function: bplib_mpool_list_iter_goto_first
+ *
+ *-----------------------------------------------------------------*/
+int bplib_mpool_list_iter_goto_first(const bplib_mpool_block_t *list, bplib_mpool_list_iter_t *iter)
+{
+    if (!bplib_mpool_is_list_head(list))
+    {
+        return BP_ERROR;
+    }
+
+    iter->pending_entry = list->next;
+
+    return bplib_mpool_list_iter_forward(iter);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_list_iter_goto_last
+ *
+ *-----------------------------------------------------------------*/
+int bplib_mpool_list_iter_goto_last(const bplib_mpool_block_t *list, bplib_mpool_list_iter_t *iter)
+{
+    if (!bplib_mpool_is_list_head(list))
+    {
+        return BP_ERROR;
+    }
+
+    iter->pending_entry = list->prev;
+
+    return bplib_mpool_list_iter_reverse(iter);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_list_iter_forward
+ *
+ *-----------------------------------------------------------------*/
+int bplib_mpool_list_iter_forward(bplib_mpool_list_iter_t *iter)
+{
+    if (bplib_mpool_is_list_head(iter->pending_entry))
+    {
+        iter->position = NULL;
+        return BP_ERROR;
+    }
+
+    iter->position      = iter->pending_entry;
+    iter->pending_entry = iter->position->next;
+    return BP_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_list_iter_reverse
+ *
+ *-----------------------------------------------------------------*/
+int bplib_mpool_list_iter_reverse(bplib_mpool_list_iter_t *iter)
+{
+    if (bplib_mpool_is_list_head(iter->pending_entry))
+    {
+        iter->position = NULL;
+        return BP_ERROR;
+    }
+
+    iter->position      = iter->pending_entry;
+    iter->pending_entry = iter->position->prev;
+    return BP_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: bplib_mpool_foreach_item_in_list
  *
  *-----------------------------------------------------------------*/

--- a/mpool/src/v7_mpool_ref.c
+++ b/mpool/src/v7_mpool_ref.c
@@ -133,13 +133,16 @@ void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr)
 {
     bplib_mpool_block_header_t *block_hdr;
 
-    block_hdr = &refptr->header;
-    if (block_hdr->refcount > 0)
+    if (refptr != NULL)
     {
-        --block_hdr->refcount;
-    }
-    if (block_hdr->refcount == 0)
-    {
-        bplib_mpool_recycle_block(pool, &block_hdr->base_link);
+        block_hdr = &refptr->header;
+        if (block_hdr->refcount > 0)
+        {
+            --block_hdr->refcount;
+        }
+        if (block_hdr->refcount == 0)
+        {
+            bplib_mpool_recycle_block(pool, &block_hdr->base_link);
+        }
     }
 }

--- a/store/v7_cache.c
+++ b/store/v7_cache.c
@@ -29,6 +29,8 @@
 #include "v7_cache.h"
 #include "v7.h"
 #include "v7_rbtree.h"
+#include "v7_codec.h"
+#include "crc.h"
 
 #include "v7_mpool.h"
 #include "v7_mpool_bblocks.h"
@@ -38,26 +40,38 @@
 /*
  * Randomly-chosen 32-bit static values that can be put into
  * data structures to help positively identify those structs later.
- *
- * Not strictly necessary, but improves debug capabilities, helping
- * to catch any typecasting errors.  This should be employed whenever
- * using the "generic data" facility in the mempool implementation,
- * because the data type is always void*, it needs another way
- * to confirm the actual content is the intended type.
  */
-#define BPLIB_STORE_SIGNATURE_STATE 0x683359a7
-#define BPLIB_STORE_SIGNATURE_ENTRY 0xf223fff9
-#define BPLIB_STORE_SIGNATURE_QUEUE 0x30241224
-#define BPLIB_STORE_SIGNATURE_BLOCK 0x77e96b11
+#define BPLIB_STORE_SIGNATURE_STATE    0x683359a7
+#define BPLIB_STORE_SIGNATURE_ENTRY    0xf223fff9
+#define BPLIB_STORE_SIGNATURE_QUEUE    0x30241224
+#define BPLIB_STORE_SIGNATURE_BLOCKREF 0x77e96b11
 
-#define BP_BUNDLE_FLAG_WITHIN_LIFETIME  0x01
-#define BP_BUNDLE_FLAG_AWAITING_CUSTODY 0x02
+#define BPLIB_STORE_HASH_SALT_DACS   0x3126c0cf
+#define BPLIB_STORE_HASH_SALT_BUNDLE 0x7739ae76
 
-#define BP_CACHE_MIN_RETX_INTERVAL 1000
+#define BPLIB_STORE_FLAG_WITHIN_LIFETIME   0x01
+#define BPLIB_STORE_FLAG_AWAITING_CUSTODY  0x02
+#define BPLIB_STORE_FLAG_AWAITING_TRANSMIT 0x04
+#define BPLIB_STORE_FLAG_LOCALLY_QUEUED    0x08
+
+/* the set of flags for which retention is required - all are typically set for valid entries
+ * if any of these becomes UN-set, retention of the entry is NOT required */
+#define BPLIB_STORE_FLAGS_RETENTION_REQUIRED (BPLIB_STORE_FLAG_WITHIN_LIFETIME | BPLIB_STORE_FLAG_AWAITING_CUSTODY)
+
+#define BPLIB_STORE_FLAGS_TRANSMIT_WAIT_STATE (BPLIB_STORE_FLAG_LOCALLY_QUEUED | BPLIB_STORE_FLAG_AWAITING_TRANSMIT)
+
+#define BP_CACHE_DACS_LIFETIME  86400000 /* 24 hrs */
+#define BP_CACHE_DACS_OPEN_TIME 1024
+
+#define BP_CACHE_IDLE_RETRY_TIME 3600000
+#define BP_CACHE_FAST_RETRY_TIME 2000
+
+#define BP_CACHE_TIME_INFINITE UINT64_MAX
 
 typedef struct bplib_store_cache_state
 {
     bplib_mpool_ref_t   self_fblk_ref;
+    bp_ipn_addr_t       self_addr;
     bplib_mpool_flow_t *self_flow;
     bplib_mpool_t      *parent_pool;
 
@@ -85,8 +99,11 @@ typedef struct bplib_store_cache_state
      */
     bplib_mpool_block_t idle_list;
 
+    bplib_rbt_root_t hash_index;
     bplib_rbt_root_t dest_eid_index;
     bplib_rbt_root_t time_index;
+
+    uint32_t generated_dacs_seq;
 
 } bplib_store_cache_state_t;
 
@@ -111,22 +128,51 @@ typedef struct bplib_store_cache_queue
 {
     bplib_rbt_link_t     rbt_link; /* must be first */
     bplib_mpool_block_t *self;
-    bplib_mpool_block_t  bundle_list;
+    bplib_mpool_block_t  bundle_list; /* jphfix - subq? */
 
 } bplib_store_cache_queue_t;
 
+typedef enum bplib_store_cache_entry_type
+{
+    bplib_store_cache_entry_type_none          = 0,
+    bplib_store_cache_entry_type_normal_bundle = 1,
+    bplib_store_cache_entry_type_pending_dacs  = 2
+} bplib_store_cache_entry_type_t;
+
+typedef struct bplib_store_cache_dacs_pending
+{
+    const bp_endpointid_buffer_t      *prev_custodian_ref;
+    bp_custody_accept_payload_block_t *payload_ref;
+
+} bplib_store_cache_dacs_pending_t;
+
+typedef union bplib_store_cache_entry_data
+{
+    bplib_store_cache_dacs_pending_t dacs;
+} bplib_store_cache_entry_data_t;
+
 typedef struct bplib_store_cache_entry
 {
-    bplib_store_cache_state_t *parent_state;
-    uint32_t                   flags;
-    bplib_mpool_ref_t          refptr;
-    uint64_t                   expire_time;
-    uint64_t                   retx_time;
-    bplib_mpool_block_t        time_link;
-    bplib_mpool_block_t        destination_link;
+    bplib_store_cache_state_t     *parent_state;
+    bplib_store_cache_entry_type_t entry_type;
+    uint32_t                       flags;
+    bplib_mpool_ref_t              refptr;
+    uint64_t                       last_eval_time; /**< DTN time when status of this entry was last checked */
+    uint64_t                       next_eval_time; /**< DTN time when status of this entry should be checked */
+    uint64_t                       expire_time;    /**< DTN time when entity is no longer useful */
+    uint64_t                       transmit_time;  /**< DTN time when entity is due to be [re]transmitted */
+    bplib_mpool_block_t            hash_link;
+    bplib_mpool_block_t            time_link;
+    bplib_mpool_block_t            destination_link;
+    bplib_store_cache_entry_data_t data;
 } bplib_store_cache_entry_t;
 
-/* Allows reconsitition of the entry struct from an RBT link pointer */
+typedef struct bplib_store_cache_blockref
+{
+    bplib_mpool_block_t *storage_entry_block;
+} bplib_store_cache_blockref_t;
+
+/* Allows reconsitition of the queue struct from an RBT link pointer */
 static inline bplib_store_cache_queue_t *bplib_store_cache_queue_from_rbt_link(const bplib_rbt_link_t *link)
 {
     /* this relies on "rbt_link" being the first entry in the struct */
@@ -153,39 +199,39 @@ static bplib_store_cache_state_t *bplib_store_cache_get_state(bplib_mpool_block_
     return state;
 }
 
+void bplib_store_cache_entry_make_pending(bplib_mpool_block_t *qblk, uint32_t set_flags, uint32_t clear_flags)
+{
+    bplib_store_cache_entry_t *store_entry;
+    bplib_mpool_block_t       *sblk;
+
+    sblk        = bplib_mpool_obtain_base_block(qblk);
+    store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
+    if (store_entry != NULL)
+    {
+        /* update the flags based on the event */
+        store_entry->flags |= set_flags;
+        store_entry->flags &= ~clear_flags;
+
+        bplib_mpool_extract_node(sblk);
+        bplib_mpool_insert_before(&store_entry->parent_state->pending_list, sblk);
+    }
+}
+
 void bplib_store_cache_handle_ref_recycle(void *arg, bplib_mpool_block_t *rblk)
 {
-    bplib_mpool_block_t          *sblk;
-    bplib_mpool_bblock_primary_t *pri_block;
-    bplib_store_cache_entry_t    *store_entry;
+    bplib_store_cache_blockref_t *block_ref;
 
-    pri_block = bplib_mpool_bblock_primary_cast(rblk);
-    if (pri_block != NULL)
+    block_ref = bplib_mpool_generic_data_cast(rblk, BPLIB_STORE_SIGNATURE_BLOCKREF);
+    if (block_ref != NULL)
     {
-        assert(pri_block->delivery_data.committed_storage_id != 0);
+        assert(block_ref->storage_entry_block != NULL);
 
-        /* The storage ID is the pointer to the storage entry block saved as an integer */
-        sblk        = (bplib_mpool_block_t *)pri_block->delivery_data.committed_storage_id;
-        store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
-        if (store_entry != NULL)
-        {
-            if (bp_handle_is_valid(pri_block->delivery_data.egress_intf_id))
-            {
-                /* bundle was successfully forwarded to a CLA; can forget about it until retransmit time */
-                /* If not doing full custody tracking, then the egress CLA is now considered the implicit custodian */
-                if (pri_block->delivery_data.delivery_policy != bplib_policy_delivery_custody_tracking)
-                {
-                    store_entry->flags &= ~BP_BUNDLE_FLAG_AWAITING_CUSTODY;
-                }
-            }
-
-            /*
-             * always put back into pending_list, this will re-evalute its current
-             * state and reclassify it as appropriate
-             */
-            bplib_mpool_extract_node(sblk);
-            bplib_mpool_insert_before(&store_entry->parent_state->pending_list, sblk);
-        }
+        /*
+         * always put back into pending_list, this will re-evalute its current
+         * state and reclassify it as appropriate.  This also clears the BPLIB_STORE_FLAG_LOCALLY_QUEUED
+         * flag.
+         */
+        bplib_store_cache_entry_make_pending(block_ref->storage_entry_block, 0, BPLIB_STORE_FLAG_LOCALLY_QUEUED);
     }
 }
 
@@ -262,47 +308,337 @@ void bplib_store_cache_add_to_subindex(bplib_mpool_t *pool, bplib_rbt_root_t *in
     }
 }
 
-void bplib_store_cache_do_transmit(bplib_store_cache_state_t *state, bplib_store_cache_entry_t *store_entry,
-                                   bplib_mpool_bblock_primary_t *pri_block)
+bp_val_t bplib_store_cache_compute_custody_hash(bp_val_t salt, const bp_endpointid_buffer_t *flow_source_eid,
+                                                const bp_endpointid_buffer_t *custodian_eid)
 {
-    bplib_mpool_block_t *rblk;
-    uint64_t             action_time;
-    bool                 was_queued;
+    bp_crcval_t                   hash;
+    bplib_crc_parameters_t *const EID_HASH_ALGORITHM = &BPLIB_CRC32_CASTAGNOLI;
 
-    /* Set egress intf to invalid - which can be used as a marker for items which are
-     * blocked from egress (it will be set valid again when it actually goes out, so if
-     * it stays invalid, that means there is no egress intf available)
-     */
-    pri_block->delivery_data.egress_intf_id = BP_INVALID_HANDLE;
+    /* use a CRC as a hash function */
+    hash = bplib_crc_initial_value(EID_HASH_ALGORITHM) ^ (bp_crcval_t)salt;
+    hash = bplib_crc_update(EID_HASH_ALGORITHM, hash, flow_source_eid, sizeof(*flow_source_eid));
+    hash = bplib_crc_update(EID_HASH_ALGORITHM, hash, custodian_eid, sizeof(*custodian_eid));
 
-    /* Check if the dest queue has any space, this is a factor in next action time */
-    was_queued = false;
-    if (bplib_mpool_subq_may_push(&state->self_flow->ingress))
+    return (bp_val_t)bplib_crc_finalize(EID_HASH_ALGORITHM, hash);
+}
+
+bplib_mpool_ref_t bplib_store_cache_create_dacs_bundle(bplib_store_cache_state_t          *state,
+                                                       bplib_mpool_bblock_primary_t      **pri_block_out,
+                                                       bp_custody_accept_payload_block_t **pay_out)
+{
+    int                  status;
+    bplib_mpool_block_t *pblk;
+    bplib_mpool_block_t *cblk;
+
+    bplib_mpool_bblock_primary_t   *pri_block;
+    bp_primary_block_t             *pri;
+    bplib_mpool_bblock_canonical_t *c_block;
+    bp_canonical_block_buffer_t    *pay;
+
+    /* This needs to turn the DACS information in the temporary object into a full bundle */
+    /* Allocate Blocks */
+    cblk   = NULL;
+    pblk   = NULL;
+    status = BP_ERROR;
+
+    do
     {
-        /* In the unlikely event that this fails, the refcount will remain 1, so it will be found again next poll */
-        rblk = bplib_mpool_ref_make_block(state->parent_pool, store_entry->refptr, BPLIB_STORE_SIGNATURE_BLOCK, NULL);
-        if (rblk != NULL)
+        pblk      = bplib_mpool_bblock_primary_alloc(state->parent_pool);
+        pri_block = bplib_mpool_bblock_primary_cast(pblk);
+        if (pri_block == NULL)
         {
-            /* put it into the queue for transmit (does not fail at this point) */
-            bplib_mpool_subq_push_single(&state->self_flow->ingress, rblk);
-            bplib_mpool_flow_mark_active(state->parent_pool, state->self_fblk_ref);
-            was_queued = true;
+            bplog(NULL, BP_FLAG_OUT_OF_MEMORY, "Failed to allocate primary block\n");
+            break;
         }
+
+        pri = bplib_mpool_bblock_primary_get_logical(pri_block);
+
+        /* Initialize Primary Block */
+        pri->version = 7;
+
+        v7_set_eid(&pri->sourceEID, &state->self_addr);
+        v7_set_eid(&pri->reportEID, &state->self_addr);
+
+        pri->creationTimeStamp.sequence_num = state->generated_dacs_seq;
+        ++state->generated_dacs_seq;
+        pri->creationTimeStamp.time = v7_get_current_time();
+
+        pri->lifetime                     = BP_CACHE_DACS_LIFETIME;
+        pri->controlFlags.isAdminRecord   = true;
+        pri->controlFlags.mustNotFragment = true;
+        pri->crctype                      = bp_crctype_CRC16;
+
+        /* Add Payload Block */
+        cblk    = bplib_mpool_bblock_canonical_alloc(state->parent_pool);
+        c_block = bplib_mpool_bblock_canonical_cast(cblk);
+        if (c_block == NULL)
+        {
+            bplog(NULL, BP_FLAG_OUT_OF_MEMORY, "Failed to allocate payload block\n");
+            break;
+        }
+
+        pay = bplib_mpool_bblock_canonical_get_logical(c_block);
+
+        pay->canonical_block.blockNum  = bp_blocktype_custodyAcceptPayloadBlock;
+        pay->canonical_block.blockType = bp_blocktype_custodyAcceptPayloadBlock;
+        pay->canonical_block.crctype   = bp_crctype_CRC16;
+
+        bplib_mpool_bblock_primary_append(pri_block, cblk);
+        cblk   = NULL; /* do not need now that it is stored */
+        status = BP_SUCCESS;
+
+        *pri_block_out = pri_block;
+        *pay_out       = &pay->data.custody_accept_payload_block;
+    }
+    while (false);
+
+    /* clean up, if anything did not work, recycle the blocks now */
+    if (cblk != NULL)
+    {
+        bplib_mpool_recycle_block(state->parent_pool, cblk);
+        cblk = NULL;
     }
 
-    /* calculate the time for the _next_ retransmit event, or expire time (whichever comes first) */
-    action_time = bplib_os_get_dtntime_ms();
-    if (was_queued)
+    if (pblk != NULL && status != BP_SUCCESS)
     {
-        action_time += pri_block->delivery_data.local_retx_interval;
+        bplib_mpool_recycle_block(state->parent_pool, pblk);
+        pblk = NULL;
+    }
+
+    return bplib_mpool_ref_create(state->parent_pool, pblk);
+}
+
+bplib_store_cache_entry_t *bplib_store_cache_open_dacs(bplib_store_cache_state_t *state, bp_val_t eid_hash,
+                                                       const bp_endpointid_buffer_t *prev_custodian,
+                                                       const bp_endpointid_buffer_t *flow_source_eid)
+{
+    bplib_mpool_block_t              *sblk;
+    bplib_store_cache_entry_t        *store_entry;
+    bplib_store_cache_dacs_pending_t *dacs_pending;
+    bplib_mpool_ref_t                 pending_bundle;
+
+    bplib_mpool_bblock_primary_t      *pri_block;
+    bp_custody_accept_payload_block_t *ack_content;
+
+    /* Create the storage-specific data block for keeping local refs  */
+    sblk           = bplib_mpool_generic_data_alloc(state->parent_pool, BPLIB_STORE_SIGNATURE_ENTRY, state);
+    pending_bundle = bplib_store_cache_create_dacs_bundle(state, &pri_block, &ack_content);
+    store_entry    = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
+    if (store_entry != NULL && pending_bundle != NULL)
+    {
+        store_entry->entry_type = bplib_store_cache_entry_type_pending_dacs;
+
+        store_entry->refptr = bplib_mpool_ref_duplicate(pending_bundle);
+
+        /* the "expire_time" here is for the local open/pending entry, not for the eventual
+         * bundle (the actual DACS bundle itself doesn't even exist yet). */
+        store_entry->expire_time   = store_entry->last_eval_time + BP_CACHE_DACS_LIFETIME;
+        store_entry->transmit_time = store_entry->last_eval_time + BP_CACHE_DACS_OPEN_TIME;
+
+        /* need to fill out the delivery_data so this will look like a regular bundle when sent */
+        pri_block->delivery_data.delivery_policy      = bplib_policy_delivery_local_ack;
+        pri_block->delivery_data.local_retx_interval  = BP_CACHE_FAST_RETRY_TIME;
+        pri_block->delivery_data.ingress_intf_id      = state->self_flow->external_id;
+        pri_block->delivery_data.ingress_time         = store_entry->last_eval_time;
+        pri_block->delivery_data.storage_intf_id      = state->self_flow->external_id;
+        pri_block->delivery_data.committed_storage_id = (bp_sid_t)sblk;
+
+        /* the ack will be sent to the previous custodian of record */
+        pri_block->pri_logical_data.destinationEID = *prev_custodian;
+        ack_content->flow_source_eid               = *flow_source_eid;
+
+        /* set convenience pointers in the dacs_pending extension data - this is mainly
+         * so these don't need to be re-found when they are needed again later */
+        dacs_pending                     = &store_entry->data.dacs;
+        dacs_pending->prev_custodian_ref = &pri_block->pri_logical_data.destinationEID;
+        dacs_pending->payload_ref        = ack_content;
+
+        bplib_store_cache_add_to_subindex(state->parent_pool, &state->hash_index, &store_entry->hash_link, eid_hash);
+        bplib_store_cache_entry_make_pending(sblk, BPLIB_STORE_FLAGS_RETENTION_REQUIRED, 0);
     }
     else
     {
-        action_time += BP_CACHE_MIN_RETX_INTERVAL;
+        if (sblk != NULL)
+        {
+            bplib_mpool_recycle_block(state->parent_pool, sblk);
+            sblk = NULL;
+        }
+
+        store_entry = NULL;
     }
-    if (action_time > store_entry->expire_time)
+
+    bplib_mpool_ref_release(state->parent_pool, pending_bundle);
+
+    return store_entry;
+}
+
+void bplib_store_cache_append_dacs(bplib_store_cache_state_t *state, bplib_store_cache_entry_t *dacs_pending,
+                                   bp_integer_t sequence)
+{
+    bp_custody_accept_payload_block_t *payload;
+
+    payload = dacs_pending->data.dacs.payload_ref;
+    if (payload->num_entries < BP_DACS_MAX_SEQ_PER_PAYLOAD)
     {
-        action_time = store_entry->expire_time;
+        payload->sequence_nums[payload->num_entries] = sequence;
+        ++payload->num_entries;
+    }
+
+    /* if DACS bundle is full now, mark it as "done" */
+    if (payload->num_entries == BP_DACS_MAX_SEQ_PER_PAYLOAD)
+    {
+        bplib_store_cache_entry_make_pending(bplib_mpool_obtain_base_block(&dacs_pending->hash_link), 0,
+                                             BPLIB_STORE_FLAG_AWAITING_TRANSMIT);
+    }
+}
+
+void bplib_store_cache_send_bundle(bplib_store_cache_state_t *state, bplib_store_cache_entry_t *store_entry)
+{
+    bplib_mpool_block_t          *rblk;
+    bplib_mpool_block_t          *eblk;
+    bplib_mpool_bblock_primary_t *pri_block;
+
+    rblk = NULL;
+    eblk = bplib_mpool_dereference(store_entry->refptr);
+
+    /* Check if the dest queue has any space, this is a factor in next action time */
+    if (bplib_mpool_subq_may_push(&state->self_flow->ingress))
+    {
+        pri_block = bplib_mpool_bblock_primary_cast(eblk);
+        if (pri_block != NULL)
+        {
+            /* Set egress intf to invalid - which can be used as a marker for items which are
+             * blocked from egress (it will be set valid again when it actually goes out, so if
+             * it stays invalid, that means there is no egress intf available) */
+            pri_block->delivery_data.egress_intf_id = BP_INVALID_HANDLE;
+        }
+
+        /* In the unlikely event that this fails, the refcount will remain 1, so it will be found again next poll */
+        rblk = bplib_mpool_ref_make_block(state->parent_pool, store_entry->refptr, BPLIB_STORE_SIGNATURE_BLOCKREF,
+                                          store_entry);
+    }
+
+    if (rblk != NULL)
+    {
+        /* put it into the queue for transmit (does not fail at this point) */
+        bplib_mpool_subq_push_single(&state->self_flow->ingress, rblk);
+        bplib_mpool_flow_mark_active(state->parent_pool, state->self_fblk_ref);
+        store_entry->flags |= BPLIB_STORE_FLAG_AWAITING_TRANSMIT;
+    }
+}
+
+bplib_mpool_block_t *bplib_store_cache_evaluate_bundle_status(bplib_store_cache_state_t *state,
+                                                              bplib_store_cache_entry_t *store_entry)
+{
+    bplib_mpool_block_t          *rblk;
+    bplib_mpool_block_t          *eblk;
+    bplib_mpool_bblock_primary_t *pri_block;
+
+    rblk      = NULL;
+    eblk      = bplib_mpool_dereference(store_entry->refptr);
+    pri_block = bplib_mpool_bblock_primary_cast(eblk);
+
+    if (pri_block != NULL)
+    {
+        /* flags indicate things that should _block_ [re]transmission - if they are all clear, send it */
+        if ((store_entry->flags & BPLIB_STORE_FLAGS_TRANSMIT_WAIT_STATE) == 0)
+        {
+            /* bundle is due for [re]transmit */
+
+            /* Set egress intf to invalid - which can be used as a marker for items which are
+             * blocked from egress (it will be set valid again when it actually goes out, so if
+             * it stays invalid, that means there is no egress intf available) */
+            pri_block->delivery_data.egress_intf_id = BP_INVALID_HANDLE;
+            pri_block->delivery_data.egress_time    = 0;
+
+            /* Check if the dest queue has any space, before creating the wrapper block */
+            if (bplib_mpool_subq_may_push(&state->self_flow->ingress))
+            {
+                rblk = bplib_mpool_ref_make_block(state->parent_pool, store_entry->refptr,
+                                                  BPLIB_STORE_SIGNATURE_BLOCKREF, store_entry);
+            }
+        }
+        else if ((store_entry->flags & BPLIB_STORE_FLAG_LOCALLY_QUEUED) == 0 &&
+                 bp_handle_is_valid(pri_block->delivery_data.egress_intf_id))
+        {
+            /* bundle is no longer locally queued here, and confirmed it was fetched by a CLA */
+            if (pri_block->delivery_data.delivery_policy != bplib_policy_delivery_custody_tracking)
+            {
+                /* If not doing full custody tracking, then the egress CLA is now considered the implicit custodian */
+                store_entry->flags &= ~BPLIB_STORE_FLAG_AWAITING_CUSTODY;
+            }
+
+            /* reschedule the next retransmit time based on the anticipted round-trip time of the egress intf */
+            /* JPHFIX: this is fixed for now, but should be configurable/specific to the egress intf */
+            store_entry->transmit_time =
+                pri_block->delivery_data.egress_time + pri_block->delivery_data.local_retx_interval;
+        }
+    }
+
+    return rblk;
+}
+
+bplib_mpool_block_t *bplib_store_cache_evaluate_pending_dacs_status(bplib_store_cache_state_t *state,
+                                                                    bplib_store_cache_entry_t *store_entry)
+{
+    bplib_mpool_block_t          *rblk;
+    bplib_mpool_block_t          *eblk;
+    bplib_mpool_bblock_primary_t *pri_block;
+
+    rblk      = NULL;
+    eblk      = bplib_mpool_dereference(store_entry->refptr);
+    pri_block = bplib_mpool_bblock_primary_cast(eblk);
+
+    /* check if bundle is due for [re]transmit */
+    if (pri_block != NULL && (store_entry->flags & BPLIB_STORE_FLAGS_TRANSMIT_WAIT_STATE) == 0)
+    {
+        /* Set egress intf to invalid - which can be used as a marker for items which are
+         * blocked from egress (it will be set valid again when it actually goes out, so if
+         * it stays invalid, that means there is no egress intf available) */
+        pri_block->delivery_data.egress_intf_id = BP_INVALID_HANDLE;
+        pri_block->delivery_data.egress_time    = 0;
+
+        /* after this point, the entry becomes a normal bundle, it is removed from EID hash
+         * so future appends are also prevented */
+        store_entry->entry_type = bplib_store_cache_entry_type_normal_bundle;
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->hash_index, &store_entry->hash_link);
+
+        /* Check if the dest queue has any space, before creating the wrapper block */
+        if (bplib_mpool_subq_may_push(&state->self_flow->ingress))
+        {
+            rblk = bplib_mpool_ref_make_block(state->parent_pool, store_entry->refptr, BPLIB_STORE_SIGNATURE_BLOCKREF,
+                                              store_entry);
+        }
+    }
+
+    return rblk;
+}
+
+void bplib_store_cache_schedule_next_visit(bplib_store_cache_state_t *state, bplib_store_cache_entry_t *store_entry)
+{
+    uint64_t ref_time;
+
+    ref_time = store_entry->last_eval_time;
+
+    if ((store_entry->flags & BPLIB_STORE_FLAGS_TRANSMIT_WAIT_STATE) == 0)
+    {
+        /* item is pending transmit but blocked for some temporary external reason, so retry more aggressively */
+        ref_time += BP_CACHE_FAST_RETRY_TIME;
+    }
+    else
+    {
+        /* item is idle for now, but don't want to leave it in a state where it is never checked again at all */
+        ref_time += BP_CACHE_IDLE_RETRY_TIME;
+    }
+
+    /* calculate the time for the _next_ retransmit event, or expire time (whichever comes first) */
+    if (ref_time > store_entry->transmit_time)
+    {
+        ref_time = store_entry->transmit_time;
+    }
+    if (ref_time > store_entry->expire_time)
+    {
+        ref_time = store_entry->expire_time;
     }
 
     /*
@@ -310,15 +646,396 @@ void bplib_store_cache_do_transmit(bplib_store_cache_state_t *state, bplib_store
      * try to batch together a group of times.  There shouldn't be a real need for millisecond-
      * level precision here, and this should hopefully reduce the block usage by consolidating
      * all entries that are on the same second.
+     *
+     * This groups together batches of 1024 ms because it can be done as a simple binary operation,
+     * as opposed to batching by 1000 ms.
      */
-    action_time = (action_time + 999) / 1000;
+    ref_time = (ref_time + 0x3FF) & ~((uint64_t)0x3FF);
 
-    /*
-     * If this was in the time index, the old entry needs to be removed first,
-     * then it needs to be added in the new spot
-     */
-    bplib_store_cache_remove_from_subindex(state->parent_pool, &state->time_index, &store_entry->time_link);
-    bplib_store_cache_add_to_subindex(state->parent_pool, &state->time_index, &store_entry->time_link, action_time);
+    if (ref_time != store_entry->next_eval_time)
+    {
+        /*
+         * If this was in the time index, the old entry needs to be removed first,
+         * then it needs to be added in the new spot
+         */
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->time_index, &store_entry->time_link);
+        bplib_store_cache_add_to_subindex(state->parent_pool, &state->time_index, &store_entry->time_link, ref_time);
+        store_entry->next_eval_time = ref_time;
+    }
+}
+
+void bplib_store_cache_evaluate_pending_entry(bplib_mpool_block_t *sblk)
+{
+    bplib_store_cache_state_t *state;
+    bplib_store_cache_entry_t *store_entry;
+    uint64_t                   now_time;
+    bool                       retention_required;
+    bplib_mpool_block_t       *rblk;
+
+    rblk = NULL;
+    /* This cast should always work, unless there is a bug */
+    store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
+    if (store_entry != NULL)
+    {
+        state = store_entry->parent_state;
+
+        /* as a catch-all/backup, items will be sent to the expired list, unless
+         * a better list is identified (such as idle_list) */
+        now_time                    = bplib_os_get_dtntime_ms();
+        store_entry->last_eval_time = now_time;
+
+        /*
+         * Check various conditions that may indicate action is needed on this bundle
+         */
+        if (now_time >= store_entry->expire_time)
+        {
+            store_entry->flags &= ~BPLIB_STORE_FLAG_WITHIN_LIFETIME;
+            store_entry->expire_time = BP_CACHE_TIME_INFINITE;
+        }
+
+        if (now_time >= store_entry->transmit_time)
+        {
+            /*
+             * Note, there is also a possibility that this bundle is gets sent to a CLA egress queue awaiting
+             * the external software entity to call cla_egress() to get it, but it never does.  This should not
+             * generate duplicate/multiple retransmit copies if that is the case.
+             *
+             * To avoid this, the "transmit_time" is set to infinite for now, and shouldn't be reset to something
+             * real until it is confirmed that there is no bundle copy in pending output anymore (that is,
+             * bplib_store_cache_handle_ref_recycle() was called and it was cleaned up).
+             *
+             * This is mainly to avoid any potential snowball effects from a misbehaving CLA.  If the CLA was
+             * not able to fetch data, it should declare itself DOWN and then all is OK (because existing entries
+             * in the egress queue get purged when an intf goes down, and we don't deliver anything new to it).
+             */
+            store_entry->flags &= ~BPLIB_STORE_FLAG_AWAITING_TRANSMIT;
+            store_entry->transmit_time = BP_CACHE_TIME_INFINITE; /* for now... */
+        }
+
+        /*
+         * Only evaluate entries which are still within their useful lifetime.  Everything
+         * else can fall through and get put into the expired list.
+         *
+         * This checks which flags are NOT set, which is easier by inverting the bits.
+         */
+        retention_required = !(~store_entry->flags & BPLIB_STORE_FLAGS_RETENTION_REQUIRED);
+
+        if (retention_required)
+        {
+            switch (store_entry->entry_type)
+            {
+                case bplib_store_cache_entry_type_normal_bundle:
+                    rblk = bplib_store_cache_evaluate_bundle_status(state, store_entry);
+                    break;
+                case bplib_store_cache_entry_type_pending_dacs:
+                    rblk = bplib_store_cache_evaluate_pending_dacs_status(state, store_entry);
+                    break;
+                default:
+                    /* nothing to do for this entry type */
+                    break;
+            }
+
+            if (rblk != NULL)
+            {
+                /* put it into the queue for transmit (does not fail at this point) */
+                bplib_mpool_subq_push_single(&state->self_flow->ingress, rblk);
+                bplib_mpool_flow_mark_active(state->parent_pool, state->self_fblk_ref);
+
+                /*
+                 * set both flags to indicate this is now in transit ...
+                 *  - item is locally queued
+                 *  - item should not be sent again until retransmit time
+                 */
+                store_entry->flags |= BPLIB_STORE_FLAGS_TRANSMIT_WAIT_STATE;
+                rblk = NULL;
+            }
+
+            /* re-evaluate after the above call */
+            retention_required = !(~store_entry->flags & BPLIB_STORE_FLAGS_RETENTION_REQUIRED);
+        }
+
+        if (retention_required)
+        {
+            /*
+             * The entry is going into the a non-expired list, so we should also ensure
+             * that a time-based next visit is also scheduled on it.  This could
+             * be far in the future, e.g. for a young bundle where the egress intf
+             * is not currently available.
+             *
+             * The main objective here is to always periodically revisit items in the
+             * idle list at some point, don't let them linger indefinitely without
+             * at least looking at them.
+             */
+            bplib_store_cache_schedule_next_visit(state, store_entry);
+            bplib_mpool_insert_before(&state->idle_list, sblk);
+        }
+        else
+        {
+            /* note - all entries in expired list will be removed from time_index and destination_index */
+            bplib_mpool_insert_before(&state->expired_list, sblk);
+        }
+    }
+}
+
+bplib_mpool_block_t *bplib_store_cache_insert_custody_tracking_block(bplib_store_cache_state_t    *state,
+                                                                     bplib_mpool_bblock_primary_t *pri_block)
+{
+    bplib_mpool_block_t            *cblk;
+    bplib_mpool_bblock_canonical_t *custody_block;
+
+    cblk = bplib_mpool_bblock_canonical_alloc(state->parent_pool);
+    if (cblk != NULL)
+    {
+        bplib_mpool_bblock_primary_append(pri_block, cblk);
+
+        custody_block = bplib_mpool_bblock_canonical_cast(cblk);
+        if (custody_block != NULL)
+        {
+            custody_block->canonical_logical_data.canonical_block.blockType = bp_blocktype_custodyTrackingBlock;
+            custody_block->canonical_logical_data.canonical_block.blockNum  = bp_blocktype_custodyTrackingBlock;
+            custody_block->canonical_logical_data.canonical_block.crctype   = pri_block->pri_logical_data.crctype;
+        }
+    }
+
+    return cblk;
+}
+
+bplib_store_cache_entry_t *bplib_store_cache_find_pending_dacs(bplib_store_cache_state_t *state, bp_val_t eid_hash,
+                                                               const bp_endpointid_buffer_t *prev_custodian,
+                                                               const bp_endpointid_buffer_t *flow_source_eid)
+{
+    bplib_rbt_link_t                 *custody_rbt_link;
+    bplib_store_cache_dacs_pending_t *dacs_pending;
+    bplib_store_cache_queue_t        *store_queue;
+    bplib_store_cache_entry_t        *store_entry;
+    bplib_mpool_list_iter_t           iter;
+    int                               status;
+
+    store_entry      = NULL;
+    custody_rbt_link = bplib_rbt_search(eid_hash, &state->hash_index);
+    if (custody_rbt_link != NULL)
+    {
+        store_queue = bplib_store_cache_queue_from_rbt_link(custody_rbt_link);
+
+        /*
+         * to handle possible hash collision/overlap, there is a list at this entry,
+         * which needs to be searched.  Collisions should be unlikely enough that
+         * the lists, if they ever become more than one entry, stay short enough
+         * such that sequential search is not a burden.
+         */
+        status = bplib_mpool_list_iter_goto_first(&store_queue->bundle_list, &iter);
+        while (true)
+        {
+            if (status != BP_SUCCESS)
+            {
+                /* no match found */
+                store_entry = NULL;
+                break;
+            }
+
+            /* possible match, but need to verify */
+            store_entry = bplib_mpool_generic_data_cast(iter.position, BPLIB_STORE_SIGNATURE_ENTRY);
+            if (store_entry != NULL && store_entry->entry_type == bplib_store_cache_entry_type_pending_dacs)
+            {
+                dacs_pending = &store_entry->data.dacs;
+
+                if (memcmp(dacs_pending->prev_custodian_ref, prev_custodian, sizeof(bp_endpointid_buffer_t)) == 0 &&
+                    memcmp(&dacs_pending->payload_ref->flow_source_eid, flow_source_eid,
+                           sizeof(bp_endpointid_buffer_t)) == 0)
+                {
+                    break;
+                }
+            }
+
+            status = bplib_mpool_list_iter_forward(&iter);
+        }
+    }
+
+    return store_entry;
+}
+
+void bplib_store_cache_ack_custody_tracking_block(bplib_store_cache_state_t    *state,
+                                                  bplib_mpool_bblock_primary_t *pri_block, bplib_mpool_block_t *cblk)
+{
+    bplib_mpool_bblock_canonical_t *custody_block;
+    bp_custody_tracking_block_t    *custody_content;
+    bplib_store_cache_entry_t      *store_entry;
+    bp_val_t                        eid_hash;
+
+    custody_block = bplib_mpool_bblock_canonical_cast(cblk);
+    if (custody_block != NULL)
+    {
+        /* need to generate a DACS back to the previous custodian indicated in the custody block */
+        custody_content = &custody_block->canonical_logical_data.data.custody_tracking_block;
+
+        if (custody_content != NULL)
+        {
+            eid_hash = bplib_store_cache_compute_custody_hash(BPLIB_STORE_HASH_SALT_DACS,
+                                                              &pri_block->pri_logical_data.sourceEID,
+                                                              &custody_content->current_custodian);
+
+            store_entry = bplib_store_cache_find_pending_dacs(state, eid_hash, &custody_content->current_custodian,
+                                                              &pri_block->pri_logical_data.sourceEID);
+            if (store_entry == NULL)
+            {
+                /* open DACS bundle did not exist - make an empty one now */
+                store_entry = bplib_store_cache_open_dacs(state, eid_hash, &custody_content->current_custodian,
+                                                          &pri_block->pri_logical_data.sourceEID);
+            }
+
+            if (store_entry != NULL)
+            {
+                bplib_store_cache_append_dacs(state, store_entry,
+                                              pri_block->pri_logical_data.creationTimeStamp.sequence_num);
+            }
+        }
+    }
+}
+
+void bplib_store_cache_update_custody_tracking_block(bplib_store_cache_state_t    *state,
+                                                     bplib_store_cache_entry_t    *store_entry,
+                                                     bplib_mpool_bblock_primary_t *pri_block, bplib_mpool_block_t *cblk)
+{
+    bplib_mpool_bblock_canonical_t *custody_block;
+    bp_custody_tracking_block_t    *custody_content;
+    bp_val_t                        eid_hash;
+
+    custody_block = bplib_mpool_bblock_canonical_cast(cblk);
+    if (custody_block != NULL)
+    {
+        custody_content = &custody_block->canonical_logical_data.data.custody_tracking_block;
+        v7_set_eid(&custody_content->current_custodian, &state->self_addr);
+
+        /* when the custody ACK for this block comes in, this block needs to be found again,
+         * so make an entry in the hash index for it */
+        eid_hash = bplib_store_cache_compute_custody_hash(
+            BPLIB_STORE_HASH_SALT_BUNDLE ^ pri_block->pri_logical_data.creationTimeStamp.sequence_num,
+            &pri_block->pri_logical_data.sourceEID, &custody_content->current_custodian);
+
+        bplib_store_cache_add_to_subindex(state->parent_pool, &state->hash_index, &store_entry->hash_link, eid_hash);
+    }
+}
+
+void bplib_store_cache_do_custody_tracking(bplib_store_cache_state_t *state, bplib_store_cache_entry_t *store_entry,
+                                           bplib_mpool_bblock_primary_t *pri_block)
+{
+    bplib_mpool_block_t *cblk;
+
+    cblk = bplib_mpool_bblock_primary_locate_canonical(pri_block, bp_blocktype_custodyTrackingBlock);
+    if (cblk != NULL)
+    {
+        /* Acknowledge the block in the bundle */
+        bplib_store_cache_ack_custody_tracking_block(state, pri_block, cblk);
+    }
+    else
+    {
+        /* There is no previous custodian, but the custody block needs to be added (because this
+         * function is only invoked where full custody tracking is enabled).  This is the case when
+         * this storage entity is the first custodian on locally generated  */
+        cblk = bplib_store_cache_insert_custody_tracking_block(state, pri_block);
+    }
+
+    if (cblk != NULL)
+    {
+        /* update the custody block to reflect the new custodian (this service) -
+         * whenever the bundle is finally forwarded, this tells the recipient to notify us */
+        bplib_store_cache_update_custody_tracking_block(state, store_entry, pri_block, cblk);
+    }
+}
+
+void bplib_store_cache_do_ack_bundle(bplib_store_cache_state_t *state, const bp_endpointid_buffer_t *prev_custodian,
+                                     const bp_endpointid_buffer_t *flow_source_eid, bp_integer_t sequence_num)
+{
+    bplib_rbt_link_t             *custody_rbt_link;
+    bplib_store_cache_queue_t    *store_queue;
+    bplib_store_cache_entry_t    *store_entry;
+    bplib_mpool_bblock_primary_t *pri_block;
+    bplib_mpool_list_iter_t       iter;
+    int                           status;
+    bp_val_t                      eid_hash;
+
+    eid_hash = bplib_store_cache_compute_custody_hash(BPLIB_STORE_HASH_SALT_BUNDLE ^ sequence_num, flow_source_eid,
+                                                      prev_custodian);
+
+    store_entry      = NULL;
+    custody_rbt_link = bplib_rbt_search(eid_hash, &state->hash_index);
+    if (custody_rbt_link != NULL)
+    {
+        store_queue = bplib_store_cache_queue_from_rbt_link(custody_rbt_link);
+
+        /*
+         * to handle possible hash collision/overlap, there is a list at this entry,
+         * which needs to be searched.  Collisions should be unlikely enough that
+         * the lists, if they ever become more than one entry, stay short enough
+         * such that sequential search is not a burden.
+         */
+        status = bplib_mpool_list_iter_goto_first(&store_queue->bundle_list, &iter);
+        while (true)
+        {
+            if (status != BP_SUCCESS)
+            {
+                /* no match found */
+                store_entry = NULL;
+                break;
+            }
+
+            /* possible match, but need to verify */
+            store_entry = bplib_mpool_generic_data_cast(iter.position, BPLIB_STORE_SIGNATURE_ENTRY);
+            if (store_entry != NULL && store_entry->entry_type == bplib_store_cache_entry_type_normal_bundle)
+            {
+                pri_block = bplib_mpool_bblock_primary_cast(bplib_mpool_dereference(store_entry->refptr));
+
+                if (pri_block != NULL && pri_block->pri_logical_data.creationTimeStamp.sequence_num == sequence_num &&
+                    memcmp(&pri_block->pri_logical_data.sourceEID, flow_source_eid, sizeof(bp_endpointid_buffer_t)) ==
+                        0)
+                {
+                    /* found it ! */
+                    printf("%s(): Got custody ACK for seq %lu\n", __func__, (unsigned long)sequence_num);
+
+                    /* can clear the flag that says it needed another custodian, and reevaluate */
+                    bplib_store_cache_entry_make_pending(&store_entry->hash_link, 0, BPLIB_STORE_FLAG_AWAITING_CUSTODY);
+                    break;
+                }
+            }
+
+            status = bplib_mpool_list_iter_forward(&iter);
+        }
+    }
+}
+
+void bplib_store_cache_process_dacs(bplib_store_cache_state_t *state, const bplib_mpool_bblock_primary_t *pri_block,
+                                    const bp_custody_accept_payload_block_t *ack_payload)
+{
+    bp_integer_t i;
+
+    for (i = 0; i < ack_payload->num_entries; ++i)
+    {
+        bplib_store_cache_do_ack_bundle(state, &pri_block->pri_logical_data.destinationEID,
+                                        &ack_payload->flow_source_eid, ack_payload->sequence_nums[i]);
+    }
+}
+
+bool bplib_store_cache_check_dacs(bplib_store_cache_state_t *state, bplib_mpool_block_t *qblk)
+{
+    bplib_mpool_bblock_primary_t   *pri_block;
+    bplib_mpool_bblock_canonical_t *c_block;
+
+    c_block   = NULL;
+    pri_block = bplib_mpool_bblock_primary_cast(qblk);
+    if (pri_block != NULL)
+    {
+        /* check if it has a custody_ack payload type */
+        c_block = bplib_mpool_bblock_canonical_cast(
+            bplib_mpool_bblock_primary_locate_canonical(pri_block, bp_blocktype_custodyAcceptPayloadBlock));
+        if (c_block != NULL)
+        {
+            /* it is an acceptance block (dacs) */
+            bplib_store_cache_process_dacs(state, pri_block,
+                                           &c_block->canonical_logical_data.data.custody_accept_payload_block);
+        }
+    }
+
+    return (c_block != NULL);
 }
 
 void bplib_store_cache_construct_entry(void *arg, bplib_mpool_block_t *sblk)
@@ -328,7 +1045,9 @@ void bplib_store_cache_construct_entry(void *arg, bplib_mpool_block_t *sblk)
     store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
     if (store_entry != NULL)
     {
-        store_entry->parent_state = arg;
+        store_entry->parent_state   = arg;
+        store_entry->last_eval_time = bplib_os_get_dtntime_ms();
+        bplib_mpool_init_secondary_link(sblk, &store_entry->hash_link);
         bplib_mpool_init_secondary_link(sblk, &store_entry->time_link);
         bplib_mpool_init_secondary_link(sblk, &store_entry->destination_link);
     }
@@ -337,14 +1056,18 @@ void bplib_store_cache_construct_entry(void *arg, bplib_mpool_block_t *sblk)
 void bplib_store_cache_destruct_entry(void *arg, bplib_mpool_block_t *sblk)
 {
     bplib_store_cache_entry_t *store_entry;
+    bplib_store_cache_state_t *state;
 
     store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
     if (store_entry != NULL)
     {
-        /* these are both secondary links, so just need to make sure they are not linked into a list,
-         * but they will be independently recycled */
-        bplib_mpool_extract_node(&store_entry->time_link);
-        bplib_mpool_extract_node(&store_entry->destination_link);
+        state = store_entry->parent_state;
+
+        /* need to make sure this is removed from all index trees */
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->hash_index, &store_entry->hash_link);
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->time_index, &store_entry->time_link);
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->dest_eid_index,
+                                               &store_entry->destination_link);
     }
 }
 
@@ -384,8 +1107,18 @@ int bplib_store_cache_egress_impl(bplib_routetbl_t *rtbl, bplib_mpool_block_t *i
 
         ++forward_count;
 
-        /* Create the storage-specific data block for keeping local refs  */
-        sblk = bplib_mpool_generic_data_alloc(state->parent_pool, BPLIB_STORE_SIGNATURE_ENTRY, state);
+        /* Is this a data bundle that needs to be stored, or is this a custody ack? */
+        if (bplib_store_cache_check_dacs(state, qblk))
+        {
+            /* it is an ACK; these do not need to be stored */
+            sblk = NULL;
+        }
+        else
+        {
+            /* Create the storage-specific data block for keeping local refs  */
+            sblk = bplib_mpool_generic_data_alloc(state->parent_pool, BPLIB_STORE_SIGNATURE_ENTRY, state);
+        }
+
         if (sblk != NULL)
         {
             /* These 2 are dynamic casts, could return NULL, but should not unless there are bugs */
@@ -397,6 +1130,8 @@ int bplib_store_cache_egress_impl(bplib_routetbl_t *rtbl, bplib_mpool_block_t *i
                 /* this is a static cast, cannot return NULL */
                 pri = bplib_mpool_bblock_primary_get_logical(pri_block);
 
+                store_entry->entry_type = bplib_store_cache_entry_type_normal_bundle;
+
                 /* this keeps a copy of the ref here, after qblk is recycled */
                 store_entry->refptr = bplib_mpool_ref_from_block(qblk);
 
@@ -406,7 +1141,7 @@ int bplib_store_cache_egress_impl(bplib_routetbl_t *rtbl, bplib_mpool_block_t *i
 
                 if (pri_block->delivery_data.delivery_policy != bplib_policy_delivery_none)
                 {
-                    store_entry->flags |= BP_BUNDLE_FLAG_AWAITING_CUSTODY;
+                    store_entry->flags |= BPLIB_STORE_FLAG_AWAITING_CUSTODY;
                 }
 
                 /*
@@ -416,17 +1151,22 @@ int bplib_store_cache_egress_impl(bplib_routetbl_t *rtbl, bplib_mpool_block_t *i
                 /* for now, assume its within lifetime, first timed poll will find out if its not */
                 /* TBD: may not want to even store it if this is not true */
                 store_entry->expire_time = pri->creationTimeStamp.time + pri->lifetime;
-                store_entry->flags |= BP_BUNDLE_FLAG_WITHIN_LIFETIME;
+                store_entry->flags |= BPLIB_STORE_FLAG_WITHIN_LIFETIME;
 
                 pri_block->delivery_data.storage_intf_id      = state->self_flow->external_id;
                 pri_block->delivery_data.committed_storage_id = (bp_sid_t)sblk;
-
-                bplib_store_cache_do_transmit(state, store_entry, pri_block);
 
                 /* NOTE:
                  * This may also be the right place to generate a custody signal, if the bundle
                  * has the full custody tracking/transfer service level.
                  */
+                if (pri_block->delivery_data.delivery_policy == bplib_policy_delivery_custody_tracking)
+                {
+                    bplib_store_cache_do_custody_tracking(state, store_entry, pri_block);
+                }
+
+                /* This puts it into the right spot for future holding */
+                bplib_store_cache_evaluate_pending_entry(sblk);
 
                 /* done with the bundle and the storage entry block (do not recycle it) */
                 sblk = NULL;
@@ -454,7 +1194,7 @@ int bplib_store_cache_egress_impl(bplib_routetbl_t *rtbl, bplib_mpool_block_t *i
     return forward_count;
 }
 
-void bplib_store_cache_cleanup_bundle(void *arg, bplib_mpool_block_t *sblk)
+void bplib_store_cache_cleanup_exipred_entry(void *arg, bplib_mpool_block_t *sblk)
 {
     bplib_store_cache_state_t *state;
     bplib_store_cache_entry_t *store_entry;
@@ -466,6 +1206,7 @@ void bplib_store_cache_cleanup_bundle(void *arg, bplib_mpool_block_t *sblk)
         state = store_entry->parent_state;
 
         /* ensure this has been removed from the various indices */
+        bplib_store_cache_remove_from_subindex(state->parent_pool, &state->hash_index, &store_entry->hash_link);
         bplib_store_cache_remove_from_subindex(state->parent_pool, &state->time_index, &store_entry->time_link);
         bplib_store_cache_remove_from_subindex(state->parent_pool, &state->dest_eid_index,
                                                &store_entry->destination_link);
@@ -476,64 +1217,10 @@ void bplib_store_cache_cleanup_bundle(void *arg, bplib_mpool_block_t *sblk)
     }
 }
 
-void bplib_store_cache_handle_bundle_pending_action(void *arg, bplib_mpool_block_t *sblk)
+void bplib_store_cache_handle_bundle_pending_list_entry(void *arg, bplib_mpool_block_t *sblk)
 {
-    bplib_store_cache_state_t    *state;
-    bplib_mpool_bblock_primary_t *pri_block;
-    bplib_mpool_block_t          *pblk;
-    bplib_mpool_block_t          *next_list;
-    bplib_store_cache_entry_t    *store_entry;
-    uint64_t                      now_time;
-
-    /* This cast should always work, unless there is a bug */
-    store_entry = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_ENTRY);
-    if (store_entry != NULL)
-    {
-        state = store_entry->parent_state;
-
-        pblk      = bplib_mpool_dereference(store_entry->refptr);
-        pri_block = bplib_mpool_bblock_primary_cast(pblk);
-        now_time  = bplib_os_get_dtntime_ms();
-        next_list = NULL;
-
-        if (pri_block != NULL)
-        {
-            /*
-             * Check various conditions that may indicate action is needed on this bundle
-             */
-            if ((store_entry->flags & BP_BUNDLE_FLAG_WITHIN_LIFETIME) == BP_BUNDLE_FLAG_WITHIN_LIFETIME &&
-                now_time >= store_entry->expire_time)
-            {
-                store_entry->flags &= ~BP_BUNDLE_FLAG_WITHIN_LIFETIME;
-            }
-
-            /*
-             * If all flags have been UN-set then this is a candidate for removal
-             * Note that this just removes the local ref, the memory for the bundle itself will not be actually
-             * recycled until the refcount also reaches 0.  Removing this ref will permit it to reach 0.
-             */
-            if ((~store_entry->flags & (BP_BUNDLE_FLAG_WITHIN_LIFETIME | BP_BUNDLE_FLAG_AWAITING_CUSTODY)) != 0)
-            {
-                next_list = &state->expired_list;
-            }
-            else
-            {
-                next_list = &state->idle_list;
-
-                /* If refcount > 1 here, that means there is already a copy in a queue
-                 * somewhere in the system.  Do not re-queue until that ref disappears */
-                if (bplib_mpool_read_refcount(pblk) <= 1 &&
-                    (!bp_handle_is_valid(pri_block->delivery_data.egress_intf_id) ||
-                     now_time >= store_entry->retx_time))
-                {
-                    bplib_store_cache_do_transmit(state, store_entry, pri_block);
-                }
-            }
-
-            /* note that this was already removed from pending_list */
-            bplib_mpool_insert_before(next_list, sblk);
-        }
-    }
+    /* this is a wrapper to make it compatible with bplib_mpool_foreach_item_in_list() */
+    bplib_store_cache_evaluate_pending_entry(sblk);
 }
 
 void bplib_store_cache_flush_pending(bplib_store_cache_state_t *state)
@@ -542,29 +1229,17 @@ void bplib_store_cache_flush_pending(bplib_store_cache_state_t *state)
     /* In some cases the bundle can get re-added to the pending list, so this is done in a loop */
     do
     {
-        bplib_mpool_foreach_item_in_list(&state->pending_list, true, bplib_store_cache_handle_bundle_pending_action,
+        bplib_mpool_foreach_item_in_list(&state->pending_list, true, bplib_store_cache_handle_bundle_pending_list_entry,
                                          state);
-        bplib_mpool_foreach_item_in_list(&state->expired_list, false, bplib_store_cache_cleanup_bundle, state);
+        bplib_mpool_foreach_item_in_list(&state->expired_list, false, bplib_store_cache_cleanup_exipred_entry, state);
         bplib_mpool_recycle_all_blocks_in_list(state->parent_pool, &state->expired_list);
     }
     while (!bplib_mpool_is_empty_list_head(&state->pending_list));
 }
 
-void bplib_store_cache_bundle_make_pending(void *arg, bplib_mpool_block_t *qblk)
+void bplib_store_cache_entry_make_pending_wrapper(void *arg, bplib_mpool_block_t *qblk)
 {
-    bplib_store_cache_state_t *state;
-    bplib_store_cache_entry_t *store_entry;
-    bplib_mpool_block_t       *pblk;
-
-    state = arg;
-
-    pblk        = bplib_mpool_obtain_base_block(qblk);
-    store_entry = bplib_mpool_generic_data_cast(pblk, BPLIB_STORE_SIGNATURE_ENTRY);
-    if (store_entry != NULL)
-    {
-        bplib_mpool_extract_node(pblk);
-        bplib_mpool_insert_before(&state->pending_list, pblk);
-    }
+    bplib_store_cache_entry_make_pending(qblk, 0, 0);
 }
 
 int bplib_store_cache_do_poll(bplib_store_cache_state_t *state)
@@ -583,7 +1258,8 @@ int bplib_store_cache_do_poll(bplib_store_cache_state_t *state)
         iter_status = bplib_rbt_iter_prev(&it);
 
         /* move the entire set of nodes on this tree entry to the pending_list */
-        bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true, bplib_store_cache_bundle_make_pending, state);
+        bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true, bplib_store_cache_entry_make_pending_wrapper,
+                                         state);
 
         /* done with this entry in the time index (will be re-added when pending_list is processed) */
         bplib_rbt_extract_node(&state->time_index, &store_queue->rbt_link);
@@ -614,7 +1290,7 @@ int bplib_store_cache_do_route_up(bplib_store_cache_state_t *state, bp_ipn_t des
         store_queue = bplib_store_cache_queue_from_rbt_link(it.position);
 
         /* move the entire set of nodes on this tree entry to the pending_list */
-        bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, false, bplib_store_cache_bundle_make_pending,
+        bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, false, bplib_store_cache_entry_make_pending_wrapper,
                                          state);
 
         /* preemptively move the iterator - the current entry will be removed,
@@ -689,6 +1365,7 @@ void bplib_store_cache_construct_state(void *arg, bplib_mpool_block_t *sblk)
         bplib_mpool_init_list_head(&state->expired_list);
         bplib_mpool_init_list_head(&state->idle_list);
 
+        bplib_rbt_init_root(&state->hash_index);
         bplib_rbt_init_root(&state->dest_eid_index);
         bplib_rbt_init_root(&state->time_index);
     }
@@ -704,7 +1381,6 @@ void bplib_store_cache_destruct_state(void *arg, bplib_mpool_block_t *sblk)
     state = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_STATE);
     if (state != NULL)
     {
-
         /* make sure all lists and indices are empty, blocks will be leaked if not */
         /* first tackle the time index */
         status = bplib_rbt_iter_goto_min(0, &state->time_index, &it);
@@ -714,15 +1390,15 @@ void bplib_store_cache_destruct_state(void *arg, bplib_mpool_block_t *sblk)
             status      = bplib_rbt_iter_next(&it);
 
             /* move the entire set of nodes on this tree entry to the pending_list */
-            bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true, bplib_store_cache_bundle_make_pending,
-                                             state);
+            bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true,
+                                             bplib_store_cache_entry_make_pending_wrapper, state);
 
-            /* done with this entry in the time index (will be re-added when pending_list is processed) */
+            /* done with this entry in the time index */
             bplib_rbt_extract_node(&state->time_index, &store_queue->rbt_link);
             bplib_mpool_recycle_block(state->parent_pool, store_queue->self);
         }
 
-        /* first tackle the destination EID index */
+        /* next tackle the destination EID index */
         status = bplib_rbt_iter_goto_min(0, &state->dest_eid_index, &it);
         while (status == BP_SUCCESS)
         {
@@ -730,11 +1406,26 @@ void bplib_store_cache_destruct_state(void *arg, bplib_mpool_block_t *sblk)
             status      = bplib_rbt_iter_next(&it);
 
             /* move the entire set of nodes on this tree entry to the pending_list */
-            bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true, bplib_store_cache_bundle_make_pending,
-                                             state);
+            bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true,
+                                             bplib_store_cache_entry_make_pending_wrapper, state);
 
-            /* done with this entry in the time index (will be re-added when pending_list is processed) */
+            /* done with this entry in the EID index */
             bplib_rbt_extract_node(&state->dest_eid_index, &store_queue->rbt_link);
+            bplib_mpool_recycle_block(state->parent_pool, store_queue->self);
+        }
+
+        status = bplib_rbt_iter_goto_min(0, &state->hash_index, &it);
+        while (status == BP_SUCCESS)
+        {
+            store_queue = bplib_store_cache_queue_from_rbt_link(it.position);
+            status      = bplib_rbt_iter_next(&it);
+
+            /* move the entire set of nodes on this tree entry to the pending_list */
+            bplib_mpool_foreach_item_in_list(&store_queue->bundle_list, true,
+                                             bplib_store_cache_entry_make_pending_wrapper, state);
+
+            /* done with this entry in the time index */
+            bplib_rbt_extract_node(&state->hash_index, &store_queue->rbt_link);
             bplib_mpool_recycle_block(state->parent_pool, store_queue->self);
         }
 
@@ -743,6 +1434,24 @@ void bplib_store_cache_destruct_state(void *arg, bplib_mpool_block_t *sblk)
         bplib_mpool_recycle_all_blocks_in_list(state->parent_pool, &state->expired_list);
 
         state->parent_pool = NULL;
+    }
+}
+
+void bplib_store_cache_construct_blockref(void *arg, bplib_mpool_block_t *sblk)
+{
+    bplib_store_cache_blockref_t *blockref;
+    bplib_store_cache_entry_t    *store_entry;
+
+    store_entry = arg;
+    blockref    = bplib_mpool_generic_data_cast(sblk, BPLIB_STORE_SIGNATURE_BLOCKREF);
+    if (blockref != NULL)
+    {
+        /*
+         * note, this needs a ref back to the block itself, not the store_entry object.
+         * but because this has two secondary links in it (time/dest index) either of
+         * these can be used to reconstitute the original block pointer.
+         */
+        blockref->storage_entry_block = bplib_mpool_obtain_base_block(&store_entry->time_link);
     }
 }
 
@@ -764,14 +1473,15 @@ void bplib_store_cache_init(bplib_mpool_t *pool)
     };
 
     const bplib_mpool_blocktype_api_t blockref_api = (bplib_mpool_blocktype_api_t) {
-        .construct = NULL,
+        .construct = bplib_store_cache_construct_blockref,
         .destruct  = bplib_store_cache_handle_ref_recycle,
     };
 
     bplib_mpool_register_blocktype(pool, BPLIB_STORE_SIGNATURE_STATE, &state_api, sizeof(bplib_store_cache_state_t));
     bplib_mpool_register_blocktype(pool, BPLIB_STORE_SIGNATURE_ENTRY, &entry_api, sizeof(bplib_store_cache_entry_t));
     bplib_mpool_register_blocktype(pool, BPLIB_STORE_SIGNATURE_QUEUE, &queue_api, sizeof(bplib_store_cache_queue_t));
-    bplib_mpool_register_blocktype(pool, BPLIB_STORE_SIGNATURE_BLOCK, &blockref_api, 0);
+    bplib_mpool_register_blocktype(pool, BPLIB_STORE_SIGNATURE_BLOCKREF, &blockref_api,
+                                   sizeof(bplib_store_cache_blockref_t));
 }
 
 bp_handle_t bplib_store_cache_attach(bplib_routetbl_t *tbl, const bp_ipn_addr_t *service_addr)
@@ -815,6 +1525,7 @@ bp_handle_t bplib_store_cache_attach(bplib_routetbl_t *tbl, const bp_ipn_addr_t 
          * creates a circular reference and prevents the refcount from ever becoming 0
          */
         state->self_fblk_ref = flow_block_ref;
+        state->self_addr     = *service_addr;
     }
 
     return storage_intf_id;

--- a/v7/inc/v7_codec.h
+++ b/v7/inc/v7_codec.h
@@ -27,6 +27,7 @@
 
 #include "bplib.h"
 #include "v7_mpool.h"
+#include "v7_types.h"
 
 /*
  * On the decode side of things, the bundle buffer is passed in from the network/CLA and all that is known will
@@ -36,7 +37,7 @@
  */
 int v7_block_decode_pri(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb, const void *data_ptr, size_t data_size);
 int v7_block_decode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr,
-                              size_t data_size);
+                              size_t data_size, bp_blocktype_t payload_block_hint);
 
 /*
  * On the encode side of things, the block types are known ahead of time.  Encoding of a payload block is separate
@@ -48,6 +49,7 @@ int v7_block_decode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_
 int v7_block_encode_pri(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb);
 int v7_block_encode_pay(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr,
                         size_t data_size);
+
 int v7_block_encode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb);
 
 size_t v7_compute_full_bundle_size(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb);


### PR DESCRIPTION
Adds a custody extension block on outgoing bundles on transmit side.

Responds to custody extension blocks with an aggregate acknowledgement bundle on recv side, which is sent back to previous custodian.

Acknowledgement bundles are identified on the previous custodian at which time the bundles are finally deleted/discarded.

Fixes #94