### PR TITLE
Fix #97, implement graular locking for maintenance tasks

### DIFF
--- a/inc/bplib.h
+++ b/inc/bplib.h
@@ -64,6 +64,8 @@ extern "C" {
 #define BP_PEND  (-1)
 #define BP_CHECK 0
 
+#define BP_DTNTIME_INFINITE UINT64_MAX
+
 /* Endpoint IDs */
 #define BP_MAX_EID_STRING 128
 #define BP_IPN_NULL       0
@@ -384,11 +386,10 @@ bp_handle_t bplib_create_node_intf(bplib_routetbl_t *rtbl, bp_ipn_t node_num);
  * @param desc Socket-like object from bplib_create_socket()
  * @param payload Pointer to buffer containing application PDU/datagram
  * @param size Size of application PDU/datagram
- * @param timeout Timeout (not yet implemented)
- * @param flags Not used (carryover)
+ * @param timeout Timeout
  * @retval BP_SUCCESS if successful
  */
-int bplib_send(bp_socket_t *desc, const void *payload, size_t size, int timeout, uint32_t *flags);
+int bplib_send(bp_socket_t *desc, const void *payload, size_t size, uint32_t timeout);
 
 /**
  * @brief Receive a single application PDU/datagram over the socket-like interface
@@ -403,11 +404,10 @@ int bplib_send(bp_socket_t *desc, const void *payload, size_t size, int timeout,
  * @param desc Socket-like object from bplib_create_socket()
  * @param payload Pointer to buffer to store application PDU/datagram
  * @param[inout] size Size of buffer on input, size of actual PDU/datagram on output
- * @param timeout Timeout (not yet implemented)
- * @param flags Not used (carryover)
+ * @param timeout Timeout
  * @retval BP_SUCCESS if successful
  */
-int bplib_recv(bp_socket_t *desc, void *payload, size_t *size, int timeout, uint32_t *flags);
+int bplib_recv(bp_socket_t *desc, void *payload, size_t *size, uint32_t timeout);
 
 /* CLA I/O (bundle data units) */
 
@@ -423,10 +423,10 @@ int bplib_recv(bp_socket_t *desc, void *payload, size_t *size, int timeout, uint
  * @param intf_id bp_handle_t value from bplib_create_cla_intf()
  * @param bundle Pointer to bundle buffer
  * @param size Size of encoded bundle
- * @param timeout Timeout (not yet implemented)
+ * @param timeout Timeout
  * @retval BP_SUCCESS if successful
  */
-int bplib_cla_ingress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, const void *bundle, size_t size, int timeout);
+int bplib_cla_ingress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, const void *bundle, size_t size, uint32_t timeout);
 
 /**
  * @brief Send complete bundle to remote system
@@ -439,10 +439,10 @@ int bplib_cla_ingress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, const void *b
  * @param intf_id bp_handle_t value from bplib_create_cla_intf()
  * @param bundle Pointer to bundle buffer
  * @param[inout] size Size of buffer on input, size of actual bundle on output
- * @param timeout Timeout (not yet implemented)
+ * @param timeout Timeout
  * @retval BP_SUCCESS if successful
  */
-int bplib_cla_egress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, void *bundle, size_t *size, int timeout);
+int bplib_cla_egress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, void *bundle, size_t *size, uint32_t timeout);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/inc/bplib_api_types.h
+++ b/inc/bplib_api_types.h
@@ -126,12 +126,6 @@ typedef struct bp_ipn_addr
 /* Storage ID */
 typedef unsigned long bp_sid_t;
 
-typedef struct bplib_stats
-{
-    uint32_t push_count;
-    uint32_t pull_count;
-} bplib_q_stats_t;
-
 typedef enum
 {
     bplib_policy_delivery_none, /**< best effort handling only, bundle may be forward directly to CLA, no need to store

--- a/inc/bplib_os.h
+++ b/inc/bplib_os.h
@@ -65,16 +65,20 @@
 void bplib_os_init(void);
 int  bplib_os_log(const char *file, unsigned int line, uint32_t *flags, uint32_t event, const char *fmt, ...)
     VARG_CHECK(printf, 5, 6);
-int         bplib_os_systime(unsigned long *sysnow); /* seconds */
-uint64_t    bplib_os_get_dtntime_ms(void); /* get the OS time compatible with the "dtn time" definition (ms resolution + dtn epoch) */
+int      bplib_os_systime(unsigned long *sysnow); /* seconds */
+uint64_t bplib_os_get_dtntime_ms(
+    void); /* get the OS time compatible with the "dtn time" definition (ms resolution + dtn epoch) */
 void        bplib_os_sleep(int seconds);
 uint32_t    bplib_os_random(void);
 bp_handle_t bplib_os_createlock(void);
 void        bplib_os_destroylock(bp_handle_t h);
 void        bplib_os_lock(bp_handle_t h);
 void        bplib_os_unlock(bp_handle_t h);
+void        bplib_os_broadcast_signal(bp_handle_t h);
+void        bplib_os_broadcast_signal_and_unlock(bp_handle_t h);
 void        bplib_os_signal(bp_handle_t h);
 int         bplib_os_waiton(bp_handle_t h, int timeout_ms);
+int         bplib_os_wait_until_ms(bp_handle_t h, uint64_t abs_dtntime_ms);
 int         bplib_os_format(char *dst, size_t len, const char *fmt, ...) VARG_CHECK(printf, 3, 4);
 int         bplib_os_strnlen(const char *str, int maxlen);
 void       *bplib_os_calloc(size_t size);

--- a/inc/bplib_routing.h
+++ b/inc/bplib_routing.h
@@ -78,7 +78,7 @@ typedef union bplib_generic_event
     bplib_route_state_event_t route_state;
 } bplib_generic_event_t;
 
-typedef int (*bplib_route_action_func_t)(bplib_routetbl_t *tbl, bplib_mpool_block_t *cb, void *arg);
+typedef int (*bplib_route_action_func_t)(bplib_routetbl_t *tbl, bplib_mpool_ref_t ref, void *arg);
 
 /******************************************************************************
  LOCAL FUNCTIONS
@@ -95,8 +95,8 @@ bp_handle_t bplib_route_register_generic_intf(bplib_routetbl_t *tbl, bp_handle_t
                                               bplib_mpool_ref_t blkref);
 
 void bplib_route_ingress_route_single_bundle(bplib_routetbl_t *tbl, bplib_mpool_block_t *pblk);
-int  bplib_route_ingress_baseintf_forwarder(bplib_routetbl_t *tbl, bplib_mpool_block_t *flow_block, void *forward_arg);
-int  bplib_route_ingress_to_parent(bplib_routetbl_t *tbl, bplib_mpool_block_t *flow_block, void *ingress_arg);
+int  bplib_route_ingress_baseintf_forwarder(bplib_routetbl_t *tbl, bplib_mpool_ref_t flow_ref, void *forward_arg);
+int  bplib_route_ingress_to_parent(bplib_routetbl_t *tbl, bplib_mpool_ref_t flow_ref, void *ingress_arg);
 
 bp_handle_t       bplib_route_bind_sub_intf(bplib_mpool_block_t *flow_block, bp_handle_t parent_intf_id);
 bplib_mpool_ref_t bplib_route_get_intf_controlblock(bplib_routetbl_t *tbl, bp_handle_t intf_id);
@@ -123,6 +123,11 @@ int bplib_route_push_egress_bundle(const bplib_routetbl_t *tbl, bp_handle_t intf
 
 int bplib_route_forward_baseintf_bundle(bplib_mpool_block_t *flow_block, void *forward_arg);
 
-void bplib_route_do_maintenance(bplib_routetbl_t *tbl);
+void bplib_route_set_maintenance_request(bplib_routetbl_t *tbl);
+void bplib_route_maintenance_request_wait(bplib_routetbl_t *tbl);
+void bplib_route_maintenance_complete_wait(bplib_routetbl_t *tbl);
+
+void bplib_route_process_active_flows(bplib_routetbl_t *tbl);
+void bplib_route_periodic_maintenance(bplib_routetbl_t *tbl);
 
 #endif

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -31,8 +31,8 @@
 typedef struct bplib_mpool_bblock_primary   bplib_mpool_bblock_primary_t;
 typedef struct bplib_mpool_bblock_canonical bplib_mpool_bblock_canonical_t;
 
-typedef struct bplib_mpool_subq bplib_mpool_subq_t;
-typedef struct bplib_mpool_flow bplib_mpool_flow_t;
+typedef struct bplib_mpool_subq_base bplib_mpool_subq_base_t;
+typedef struct bplib_mpool_flow      bplib_mpool_flow_t;
 
 /**
  * @brief A reference to another mpool block
@@ -522,6 +522,6 @@ bplib_mpool_t *bplib_mpool_create(void *pool_mem, size_t pool_size);
 /* DEBUG/TEST verification routines */
 
 void bplib_mpool_debug_scan(bplib_mpool_t *pool);
-void bplib_mpool_debug_print_queue_stats(bplib_mpool_block_t *list, const char *label);
+void bplib_mpool_debug_print_list_stats(bplib_mpool_block_t *list, const char *label);
 
 #endif /* V7_MPOOL_H */

--- a/mpool/inc/v7_mpool_flows.h
+++ b/mpool/inc/v7_mpool_flows.h
@@ -38,19 +38,33 @@
  */
 #define BP_MPOOL_MAX_SUBQ_DEPTH 0x10000000
 
-struct bplib_mpool_subq
+struct bplib_mpool_subq_base
 {
-    bplib_mpool_block_t block_listx;
-    bplib_q_stats_t     stats;
-    uint32_t            current_depth_limit;
+    bplib_mpool_block_t block_list;
+
+    /* note - "unsigned int" is chosen here as it is likely to be
+     * a single-cycle read in most CPUs.  The range is not as critical
+     * because what matters is the difference between these values.
+     * The "volatile" qualification helps ensure the values are read as they
+     * appear in code and are not rearranged by the compiler, as they could
+     * be changed by other threads.  */
+    volatile unsigned int push_count;
+    volatile unsigned int pull_count;
 };
+
+typedef struct bplib_mpool_subq_depthlimit
+{
+    bplib_mpool_subq_base_t base_subq;
+    unsigned int            current_depth_limit;
+} bplib_mpool_subq_depthlimit_t;
 
 struct bplib_mpool_flow
 {
-    bp_handle_t        external_id;
-    bplib_mpool_subq_t ingress;
-    bplib_mpool_subq_t egress;
-    bplib_mpool_ref_t  parent;
+    bp_handle_t       external_id;
+    bplib_mpool_ref_t parent;
+
+    bplib_mpool_subq_depthlimit_t ingress;
+    bplib_mpool_subq_depthlimit_t egress;
 };
 
 /**
@@ -72,31 +86,6 @@ bplib_mpool_flow_t *bplib_mpool_flow_cast(bplib_mpool_block_t *cb);
 bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg);
 
 /**
- * @brief Append a single bundle to the given queue (flow)
- *
- * @param subq
- * @param cpb
- */
-void bplib_mpool_subq_push_single(bplib_mpool_subq_t *subq, bplib_mpool_block_t *cpb);
-
-/**
- * @brief Get the next bundle from the given queue (flow)
- *
- * @param subq
- * @return bplib_mpool_block_t*
- */
-bplib_mpool_block_t *bplib_mpool_subq_pull_single(bplib_mpool_subq_t *subq);
-
-/**
- * @brief Merges the entire contents of the source subq into the destination
- *
- * @param subq_dst
- * @param subq_src
- * @return The number of queue entries moved
- */
-uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_t *subq_dst, bplib_mpool_subq_t *subq_src);
-
-/**
  * @brief Drops the entire contents of a subq
  *
  * This purges the contents of a queue, such as when the interface is set to a "down" state,
@@ -106,39 +95,54 @@ uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_t *subq_dst, bplib_mpool_sub
  * @param subq
  * @return uint32_t
  */
-uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_t *subq);
+uint32_t bplib_mpool_subq_depthlimit_disable(bplib_mpool_t *pool, bplib_mpool_subq_depthlimit_t *subq);
+
+bool     bplib_mpool_subq_depthlimit_try_push(bplib_mpool_t *pool, bplib_mpool_ref_t flow_dst_ref,
+                                              bplib_mpool_subq_depthlimit_t *subq_dst, bplib_mpool_block_t *qblk,
+                                              uint64_t abs_timeout);
+uint32_t bplib_mpool_subq_depthlimit_try_move_all(bplib_mpool_t *pool, bplib_mpool_ref_t flow_dst_ref,
+                                                  bplib_mpool_subq_depthlimit_t *subq_dst,
+                                                  bplib_mpool_subq_depthlimit_t *subq_src, uint64_t abs_timeout);
+
+bplib_mpool_block_t *bplib_mpool_subq_depthlimit_try_pull(bplib_mpool_t *pool, bplib_mpool_ref_t flow_src_ref,
+                                                          bplib_mpool_subq_depthlimit_t *subq_src,
+                                                          uint64_t                       abs_timeout);
 
 /**
  * @brief Get the current depth of a given subq
  *
+ * @note If this is called outside of a lock, the results may be indeterminate because
+ * the state may change by the time the result is returned.  However, since 32-bit reads
+ * are generally atomic on most CPUs, it should be sufficiently safe to call while unlocked
+ * if the caller ensures that the calling task is the only thread currently during
+ * pushes or pulls - thereby ensuring that at least one of the values will be stable
+ * between the check and the actual push/pull.  In the event that the value changes
+ * between the time of check and time of use, it will only be "better" (that is, if the
+ * caller is pulling, the depth can only go up if another thread pushes, and if the
+ * caller is pushing, the depth can only go down if another thread pulls).
+ *
  * @param subq
  * @returns Current depth of queue
  */
-static inline uint32_t bplib_mpool_subq_get_depth(bplib_mpool_subq_t *subq)
+static inline uint32_t bplib_mpool_subq_get_depth(const bplib_mpool_subq_base_t *subq)
 {
-    return (subq->stats.push_count - subq->stats.pull_count);
-}
-
-/**
- * @brief Check if given subq can accomodate additional entries
- *
- * @param subq
- * @retval true if subq can accomodate at least one more entry
- */
-static inline bool bplib_mpool_subq_may_push(bplib_mpool_subq_t *subq)
-{
-    return (bplib_mpool_subq_get_depth(subq) < subq->current_depth_limit);
+    return (subq->push_count - subq->pull_count);
 }
 
 /**
  * @brief Check if given subq has any content
  *
+ * @note This check is lockless, therefore the state of the subq may change at any time
+ * if other threads/tasks are pulling from the same subq.  Therefore even if this function
+ * returns true, it does not guarantee that a subsequent call to
+ * bplib_mpool_subq_depthlimit_try_pull() will return a valid block.
+ *
  * @param subq
  * @retval true if subq has at least one entry
  */
-static inline bool bplib_mpool_subq_may_pull(bplib_mpool_subq_t *subq)
+static inline bool bplib_mpool_subq_depthlimit_may_pull(const bplib_mpool_subq_depthlimit_t *subq)
 {
-    return (bplib_mpool_subq_get_depth(subq) > 0);
+    return (bplib_mpool_subq_get_depth(&subq->base_subq) != 0);
 }
 
 /**
@@ -146,22 +150,25 @@ static inline bool bplib_mpool_subq_may_pull(bplib_mpool_subq_t *subq)
  *
  * This marks it so it will be processed during the next call to forward data
  *
+ * @note This is handled automatically by functions which append to a flow subq, such
+ * as bplib_mpool_subq_depthlimit_try_push() and bplib_mpool_subq_depthlimit_try_move_all().
+ * Applictions only need to explicitly call this API to mark it as active if there is
+ * some other factor that requires it to be processed again.
+ *
  * @param pool
- * @param flow
+ * @param flow_ref
  */
 void bplib_mpool_flow_mark_active(bplib_mpool_t *pool, bplib_mpool_ref_t flow_ref);
 
 /**
- * @brief Process (forward) all active flows in the system
+ * @brief Get the next active flow in the pool
  *
  * The given callback function will be invoked for all flows which are
  * currently marked as active
  *
  * @param pool
- * @param callback_fn
- * @param callback_arg
- * @return int
+ * @return bplib_mpool_ref_t
  */
-int bplib_mpool_flow_process_active(bplib_mpool_t *pool, bplib_mpool_callback_func_t callback_fn, void *callback_arg);
+bplib_mpool_ref_t bplib_mpool_flow_get_next_active(bplib_mpool_t *pool);
 
 #endif /* V7_MPOOL_FLOWS_H */

--- a/mpool/src/v7_mpool_bblocks.c
+++ b/mpool/src/v7_mpool_bblocks.c
@@ -130,8 +130,15 @@ void bplib_mpool_bblock_canonical_init(bplib_mpool_bblock_canonical_t *cblk)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
 {
-    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary,
-                                                                   MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE, NULL);
+    bplib_mpool_block_content_t *result;
+    bplib_mpool_lock_t          *lock;
+
+    lock   = bplib_mpool_lock_resource(pool);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary, MPOOL_CACHE_PRIMARY_BLOCK_SIGNATURE,
+                                              NULL);
+    bplib_mpool_lock_release(lock);
+
+    return (bplib_mpool_block_t *)result;
 }
 
 /*----------------------------------------------------------------
@@ -141,8 +148,15 @@ bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool)
 {
-    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical,
-                                                                   MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE, NULL);
+    bplib_mpool_block_content_t *result;
+    bplib_mpool_lock_t          *lock;
+
+    lock   = bplib_mpool_lock_resource(pool);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical,
+                                              MPOOL_CACHE_CANONICAL_BLOCK_SIGNATURE, NULL);
+    bplib_mpool_lock_release(lock);
+
+    return (bplib_mpool_block_t *)result;
 }
 
 /*----------------------------------------------------------------
@@ -152,8 +166,15 @@ bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_bblock_cbor_alloc(bplib_mpool_t *pool)
 {
-    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_cbor_data,
-                                                                   MPOOL_CACHE_CBOR_DATA_SIGNATURE, NULL);
+    bplib_mpool_block_content_t *result;
+    bplib_mpool_lock_t          *lock;
+
+    lock = bplib_mpool_lock_resource(pool);
+    result =
+        bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_cbor_data, MPOOL_CACHE_CBOR_DATA_SIGNATURE, NULL);
+    bplib_mpool_lock_release(lock);
+
+    return (bplib_mpool_block_t *)result;
 }
 
 /*----------------------------------------------------------------

--- a/mpool/src/v7_mpool_flows.c
+++ b/mpool/src/v7_mpool_flows.c
@@ -38,10 +38,18 @@
  * Function: bplib_mpool_subq_init
  *
  *-----------------------------------------------------------------*/
-void bplib_mpool_subq_init(bplib_mpool_subq_t *qblk)
+void bplib_mpool_subq_init(bplib_mpool_subq_base_t *qblk)
 {
     /* init the link structs */
-    bplib_mpool_init_list_head(&qblk->block_listx);
+    bplib_mpool_init_list_head(&qblk->block_list);
+    qblk->pull_count = 0;
+    qblk->push_count = 0;
+}
+
+void bplib_mpool_subq_depthlimit_init(bplib_mpool_subq_depthlimit_t *qblk)
+{
+    bplib_mpool_subq_init(&qblk->base_subq);
+    qblk->current_depth_limit = 0;
 }
 
 /*----------------------------------------------------------------
@@ -49,12 +57,50 @@ void bplib_mpool_subq_init(bplib_mpool_subq_t *qblk)
  * Function: bplib_mpool_subq_push_single
  *
  *-----------------------------------------------------------------*/
-void bplib_mpool_subq_push_single(bplib_mpool_subq_t *subq, bplib_mpool_block_t *cpb)
+void bplib_mpool_subq_push_single(bplib_mpool_subq_base_t *subq, bplib_mpool_block_t *cpb)
 {
-    /* checks that it is some form of primary bundle */
-    assert(bplib_mpool_bblock_primary_cast(cpb) != NULL);
-    bplib_mpool_insert_before(&subq->block_listx, cpb);
-    ++subq->stats.push_count;
+    bplib_mpool_insert_before(&subq->block_list, cpb);
+    ++subq->push_count;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_list_count_blocks
+ *
+ *-----------------------------------------------------------------*/
+uint32_t bplib_mpool_list_count_blocks(bplib_mpool_block_t *list)
+{
+    bplib_mpool_block_t *node;
+    uint32_t             count;
+
+    node  = list->next;
+    count = 0;
+    while (node != list)
+    {
+        ++count;
+        node = node->next;
+    }
+
+    return count;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_subq_merge_list
+ *
+ *-----------------------------------------------------------------*/
+uint32_t bplib_mpool_subq_merge_list(bplib_mpool_subq_base_t *subq_dst, bplib_mpool_block_t *list)
+{
+    uint32_t block_count;
+
+    /* for record-keeping, must count the blocks to know how many are being moved here */
+    block_count = bplib_mpool_list_count_blocks(list);
+
+    bplib_mpool_merge_list(&subq_dst->block_list, list);
+    bplib_mpool_extract_node(list);
+    subq_dst->push_count += block_count;
+
+    return block_count;
 }
 
 /*----------------------------------------------------------------
@@ -62,7 +108,7 @@ void bplib_mpool_subq_push_single(bplib_mpool_subq_t *subq, bplib_mpool_block_t 
  * Function: bplib_mpool_subq_move_all
  *
  *-----------------------------------------------------------------*/
-uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_t *subq_dst, bplib_mpool_subq_t *subq_src)
+uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_base_t *subq_dst, bplib_mpool_subq_base_t *subq_src)
 {
     uint32_t queue_depth;
 
@@ -70,10 +116,10 @@ uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_t *subq_dst, bplib_mpool_sub
     queue_depth = bplib_mpool_subq_get_depth(subq_src);
     if (queue_depth > 0)
     {
-        bplib_mpool_merge_list(&subq_dst->block_listx, &subq_src->block_listx);
-        bplib_mpool_extract_node(&subq_src->block_listx);
-        subq_src->stats.pull_count += queue_depth;
-        subq_dst->stats.push_count += queue_depth;
+        bplib_mpool_merge_list(&subq_dst->block_list, &subq_src->block_list);
+        bplib_mpool_extract_node(&subq_src->block_list);
+        subq_src->pull_count += queue_depth;
+        subq_dst->push_count += queue_depth;
     }
     return queue_depth;
 }
@@ -83,7 +129,7 @@ uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_t *subq_dst, bplib_mpool_sub
  * Function: bplib_mpool_subq_drop_all
  *
  *-----------------------------------------------------------------*/
-uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_t *subq)
+uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_base_t *subq)
 {
     uint32_t queue_depth;
 
@@ -91,8 +137,8 @@ uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_t *subq
     queue_depth = bplib_mpool_subq_get_depth(subq);
     if (queue_depth > 0)
     {
-        bplib_mpool_recycle_all_blocks_in_list(pool, &subq->block_listx);
-        subq->stats.pull_count += queue_depth;
+        bplib_mpool_recycle_all_blocks_in_list(pool, &subq->block_list);
+        subq->pull_count += queue_depth;
     }
     return queue_depth;
 }
@@ -102,18 +148,19 @@ uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_t *subq
  * Function: bplib_mpool_subq_pull_single
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_block_t *bplib_mpool_subq_pull_single(bplib_mpool_subq_t *subq)
+bplib_mpool_block_t *bplib_mpool_subq_pull_single(bplib_mpool_subq_base_t *subq)
 {
-    bplib_mpool_block_t *node = subq->block_listx.next;
+    bplib_mpool_block_t *node;
 
     /* if the head is reached here, then the list is empty */
+    node = subq->block_list.next;
     if (bplib_mpool_is_list_head(node))
     {
         return NULL;
     }
 
     bplib_mpool_extract_node(node);
-    ++subq->stats.pull_count;
+    ++subq->pull_count;
 
     return node;
 }
@@ -144,13 +191,210 @@ bplib_mpool_flow_t *bplib_mpool_flow_cast(bplib_mpool_block_t *cb)
 void bplib_mpool_flow_mark_active(bplib_mpool_t *pool, bplib_mpool_ref_t flow_ref)
 {
     bplib_mpool_block_content_t *content;
+    bplib_mpool_lock_t          *lock;
 
     content = (bplib_mpool_block_content_t *)bplib_mpool_obtain_base_block(bplib_mpool_dereference(flow_ref));
     if (content != NULL && content->header.base_link.type == bplib_mpool_blocktype_flow)
     {
+        lock = bplib_mpool_lock_resource(pool);
+
+        /* puts this note at the back of the list, but first remove it if it was already on the list */
+        /* this permits it to be marked as active multiple times, it will still only be in the list once */
         bplib_mpool_extract_node(&content->u.flow.processable_link);
-        bplib_mpool_insert_before(&pool->active_flow_list, &content->u.flow.processable_link);
+        bplib_mpool_insert_before(&pool->active_list, &content->u.flow.processable_link);
+
+        bplib_mpool_lock_broadcast_release(lock);
     }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_subq_depthlimit_wait_for_space
+ *
+ * Internal function, lock must be held when invoked
+ *
+ *-----------------------------------------------------------------*/
+bool bplib_mpool_subq_depthlimit_wait_for_space(bplib_mpool_lock_t *lock, bplib_mpool_subq_depthlimit_t *subq,
+                                                uint32_t quantity, uint64_t abs_timeout)
+{
+    uint32_t next_depth;
+    bool     within_timeout;
+
+    /* future depth after adding given quantity */
+    next_depth     = bplib_mpool_subq_get_depth(&subq->base_subq) + quantity;
+    within_timeout = (abs_timeout != 0);
+    while (next_depth > subq->current_depth_limit && within_timeout)
+    {
+        /* adding given quantity would overfill, wait for something else to pull */
+        within_timeout = bplib_mpool_lock_wait(lock, abs_timeout);
+        next_depth     = bplib_mpool_subq_get_depth(&subq->base_subq) + quantity;
+    }
+
+    return (next_depth <= subq->current_depth_limit);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_subq_depthlimit_wait_for_space
+ *
+ * Internal function, lock must be held when invoked
+ *
+ *-----------------------------------------------------------------*/
+bool bplib_mpool_subq_depthlimit_wait_for_fill(bplib_mpool_lock_t *lock, bplib_mpool_subq_depthlimit_t *subq,
+                                               uint32_t quantity, uint64_t abs_timeout)
+{
+    uint32_t curr_depth;
+    bool     within_timeout;
+
+    curr_depth     = bplib_mpool_subq_get_depth(&subq->base_subq);
+    within_timeout = (abs_timeout != 0);
+    while (curr_depth < quantity && within_timeout)
+    {
+        within_timeout = bplib_mpool_lock_wait(lock, abs_timeout);
+        curr_depth     = bplib_mpool_subq_get_depth(&subq->base_subq);
+    }
+
+    return (curr_depth >= quantity);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_subq_depthlimit_try_push
+ *
+ *-----------------------------------------------------------------*/
+bool bplib_mpool_subq_depthlimit_try_push(bplib_mpool_t *pool, bplib_mpool_ref_t flow_dst_ref,
+                                          bplib_mpool_subq_depthlimit_t *subq_dst, bplib_mpool_block_t *qblk,
+                                          uint64_t abs_timeout)
+{
+    bplib_mpool_block_content_t *content;
+    bplib_mpool_lock_t          *lock;
+    bool                         got_space;
+
+    got_space = false;
+    content   = (bplib_mpool_block_content_t *)bplib_mpool_obtain_base_block(bplib_mpool_dereference(flow_dst_ref));
+    if (content != NULL && content->header.base_link.type == bplib_mpool_blocktype_flow)
+    {
+        lock = bplib_mpool_lock_resource(pool);
+
+        got_space = bplib_mpool_subq_depthlimit_wait_for_space(lock, subq_dst, 1, abs_timeout);
+        if (got_space)
+        {
+            /* this does not fail, but must be done under lock to keep things consistent */
+            bplib_mpool_subq_push_single(&subq_dst->base_subq, qblk);
+
+            /* mark the flow as "active" - done directly here while the lock is still held */
+            bplib_mpool_extract_node(&content->u.flow.processable_link);
+            bplib_mpool_insert_before(&pool->active_list, &content->u.flow.processable_link);
+        }
+
+        /* this uses broadcast in case any threads were waiting on a non-empty queue */
+        bplib_mpool_lock_broadcast_release(lock);
+    }
+
+    return got_space;
+}
+
+bplib_mpool_block_t *bplib_mpool_subq_depthlimit_try_pull(bplib_mpool_t *pool, bplib_mpool_ref_t flow_src_ref,
+                                                          bplib_mpool_subq_depthlimit_t *subq_src, uint64_t abs_timeout)
+{
+    bplib_mpool_block_content_t *content;
+    bplib_mpool_lock_t          *lock;
+    bplib_mpool_block_t         *qblk;
+    bool                         got_space;
+
+    got_space = false;
+    qblk      = NULL;
+    content   = (bplib_mpool_block_content_t *)bplib_mpool_obtain_base_block(bplib_mpool_dereference(flow_src_ref));
+    if (content != NULL && content->header.base_link.type == bplib_mpool_blocktype_flow)
+    {
+        lock = bplib_mpool_lock_resource(pool);
+
+        got_space = bplib_mpool_subq_depthlimit_wait_for_fill(lock, subq_src, 1, abs_timeout);
+        if (got_space)
+        {
+            qblk = bplib_mpool_subq_pull_single(&subq_src->base_subq);
+        }
+
+        /* this uses broadcast in case any threads were waiting on a non-full queue */
+        bplib_mpool_lock_broadcast_release(lock);
+    }
+
+    return qblk;
+}
+
+uint32_t bplib_mpool_subq_depthlimit_try_move_all(bplib_mpool_t *pool, bplib_mpool_ref_t flow_dst_ref,
+                                                  bplib_mpool_subq_depthlimit_t *subq_dst,
+                                                  bplib_mpool_subq_depthlimit_t *subq_src, uint64_t abs_timeout)
+{
+    bplib_mpool_block_content_t *content;
+    bplib_mpool_lock_t          *lock;
+    uint32_t                     prev_quantity;
+    uint32_t                     quantity;
+    bool                         got_space;
+
+    got_space = false;
+    content   = (bplib_mpool_block_content_t *)bplib_mpool_obtain_base_block(bplib_mpool_dereference(flow_dst_ref));
+    if (content != NULL && content->header.base_link.type == bplib_mpool_blocktype_flow)
+    {
+        lock = bplib_mpool_lock_resource(pool);
+
+        /* note, there is a possibility that while waiting, another task puts more entries
+         * into the source queue.  This loop will catch that and wait again.  However it
+         * will not catch the case of another thread taking out of the source queue, as
+         * it will still wait for the original amount. */
+        quantity = bplib_mpool_subq_get_depth(&subq_src->base_subq);
+        do
+        {
+            prev_quantity = quantity;
+            got_space     = bplib_mpool_subq_depthlimit_wait_for_space(lock, subq_dst, quantity, abs_timeout);
+            quantity      = bplib_mpool_subq_get_depth(&subq_src->base_subq);
+        }
+        while (got_space && quantity > prev_quantity);
+
+        if (got_space)
+        {
+            /* this does not fail, but must be done under lock to keep things consistent */
+            quantity = bplib_mpool_subq_move_all(&subq_dst->base_subq, &subq_src->base_subq);
+
+            /* mark the flow as "active" - done directly here while the lock is still held */
+            bplib_mpool_extract_node(&content->u.flow.processable_link);
+            bplib_mpool_insert_before(&pool->active_list, &content->u.flow.processable_link);
+        }
+        else
+        {
+            quantity = 0;
+        }
+
+        /* this uses broadcast in case any threads were waiting on a non-full/empty queue */
+        bplib_mpool_lock_broadcast_release(lock);
+    }
+    else
+    {
+        quantity = 0;
+    }
+
+    return quantity;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_subq_depthlimit_disable
+ *
+ *-----------------------------------------------------------------*/
+uint32_t bplib_mpool_subq_depthlimit_disable(bplib_mpool_t *pool, bplib_mpool_subq_depthlimit_t *subq)
+{
+    bplib_mpool_lock_t *lock;
+    uint32_t            quantity_dropped;
+
+    lock = bplib_mpool_lock_resource(pool);
+
+    /* prevents any additional entries in flow queues */
+    subq->current_depth_limit = 0;
+    quantity_dropped          = bplib_mpool_subq_drop_all(pool, &subq->base_subq);
+
+    bplib_mpool_lock_release(lock);
+
+    return quantity_dropped;
 }
 
 /*----------------------------------------------------------------
@@ -161,8 +405,8 @@ void bplib_mpool_flow_mark_active(bplib_mpool_t *pool, bplib_mpool_ref_t flow_re
 void bplib_mpool_flow_init(bplib_mpool_flow_t *fblk)
 {
     /* now init the link structs */
-    bplib_mpool_subq_init(&fblk->ingress);
-    bplib_mpool_subq_init(&fblk->egress);
+    bplib_mpool_subq_depthlimit_init(&fblk->ingress);
+    bplib_mpool_subq_depthlimit_init(&fblk->egress);
 }
 
 /*----------------------------------------------------------------
@@ -172,36 +416,46 @@ void bplib_mpool_flow_init(bplib_mpool_flow_t *fblk)
  *-----------------------------------------------------------------*/
 bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg)
 {
-    return (bplib_mpool_block_t *)bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number,
-                                                                   init_arg);
+    bplib_mpool_block_content_t *result;
+    bplib_mpool_lock_t          *lock;
+
+    lock   = bplib_mpool_lock_resource(pool);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number, init_arg);
+    bplib_mpool_lock_release(lock);
+
+    return (bplib_mpool_block_t *)result;
 }
 
 /*----------------------------------------------------------------
  *
- * Function: bplib_mpool_flow_process_active
+ * Function: bplib_mpool_flow_get_next_active
  *
  *-----------------------------------------------------------------*/
-int bplib_mpool_flow_process_active(bplib_mpool_t *pool, bplib_mpool_callback_func_t callback_fn, void *callback_arg)
+bplib_mpool_ref_t bplib_mpool_flow_get_next_active(bplib_mpool_t *pool)
 {
-    bplib_mpool_block_t temp_list;
-    int                 count;
+    bplib_mpool_lock_t  *lock;
+    bplib_mpool_block_t *fblk;
 
-    /*
-     * To address the possibility that the callback puts the item into the same
-     * list it was originally in, first make a separate temp list and move all
-     * the items into that.  This should ensure that this only processes
-     * the contents once, even if the callback puts it back into the orginal list.
-     * While that still might create an infinite loop at the next level up,
-     * it won't create an infinite loop here at least.
-     */
-    bplib_mpool_init_list_head(&temp_list);
-    bplib_mpool_merge_list(&temp_list, &pool->active_flow_list);
-    bplib_mpool_extract_node(&pool->active_flow_list);
+    lock = bplib_mpool_lock_resource(pool);
 
-    count = bplib_mpool_foreach_item_in_list(&temp_list, true, callback_fn, callback_arg);
+    /* if the head is reached here, then the list is empty */
+    fblk = bplib_mpool_get_next_block(&pool->active_list);
+    if (bplib_mpool_is_list_head(fblk))
+    {
+        fblk = NULL;
+    }
+    else
+    {
+        bplib_mpool_extract_node(fblk);
+    }
 
-    /* this should have moved everything - if non-empty then nodes will be leaked! */
-    assert(bplib_mpool_is_empty_list_head(&temp_list));
+    bplib_mpool_lock_release(lock);
 
-    return count;
+    if (fblk == NULL)
+    {
+        return NULL;
+    }
+
+    fblk = bplib_mpool_obtain_base_block(fblk);
+    return bplib_mpool_ref_duplicate((bplib_mpool_ref_t)fblk);
 }

--- a/mpool/src/v7_mpool_internal.h
+++ b/mpool/src/v7_mpool_internal.h
@@ -35,6 +35,11 @@
  */
 #define BP_MPOOL_MIN_USER_BLOCK_SIZE 320
 
+typedef struct bplib_mpool_lock
+{
+    bp_handle_t lock_id;
+} bplib_mpool_lock_t;
+
 typedef struct bplib_mpool_block_header
 {
     bplib_mpool_block_t base_link; /* must be first - this is the pointer used in the application */
@@ -120,29 +125,191 @@ struct mpool
 {
     size_t   buffer_size;
     uint32_t num_bufs_total;
-    uint32_t alloc_threshold;
-    uint32_t alloc_count;
-    uint32_t recycled_count;
+    uint32_t bblock_alloc_threshold;   /**< threshold at which new bundles will no longer be allocatable */
+    uint32_t internal_alloc_threshold; /**< threshold at which internal blocks will no longer be allocatable */
 
-    bplib_mpool_api_content_t blocktype_basic;
-    bplib_rbt_root_t          xblocktype_registry;
+    bplib_rbt_root_t          blocktype_registry; /**< registry of block signature values */
+    bplib_mpool_api_content_t blocktype_basic;    /**< a fixed entity in the registry for type 0 */
 
-    bplib_mpool_block_t free_blocks;
-    bplib_mpool_block_t ref_managed_blocks;
-    bplib_mpool_block_t recycle_blocks;
-    bplib_mpool_block_t active_flow_list;
+    bplib_mpool_subq_base_t free_blocks;    /**< blocks which are available for use */
+    bplib_mpool_subq_base_t recycle_blocks; /**< blocks which can be garbage-collected */
 
-    bplib_mpool_block_content_t first_buffer;
+    /* note that the active_list and managed_block_list are not FIFO in nature, as blocks
+     * can be removed from the middle of the list or otherwise rearranged. Therefore a subq
+     * is not used for these, because the push_count and pull_count would not remain accurate. */
+
+    bplib_mpool_block_t active_list;        /**< a list of flows/queues that need processing */
+    bplib_mpool_block_t managed_block_list; /**< a list of blocks that are refcount-managed */
+
+    bplib_mpool_block_content_t first_buffer; /**< Start of first real block (see num_bufs_total) */
 };
 
 #define MPOOL_GET_BUFFER_USER_START_OFFSET(m) (offsetof(bplib_mpool_block_buffer_t, m.user_data_start))
 
 #define MPOOL_GET_BLOCK_USER_CAPACITY(m) (sizeof(bplib_mpool_block_buffer_t) - MPOOL_GET_BUFFER_USER_START_OFFSET(m))
 
+/**
+ * @brief Acquires a given lock
+ *
+ * The lock should be identified via bplib_mpool_lock_prepare() or this
+ * can re-acquire the same lock again after releasing it with
+ * bplib_mpool_lock_release().
+ *
+ * @param lock
+ */
+static inline void bplib_mpool_lock_acquire(bplib_mpool_lock_t *lock)
+{
+    bplib_os_lock(lock->lock_id);
+}
+
+/**
+ * @brief Release a given lock (simple)
+ *
+ * This simply unlocks a resource.
+ *
+ * This API will NOT automatically wake any task that might be waiting for a
+ * state change of the underlying resource
+ *
+ * @param lock
+ */
+static inline void bplib_mpool_lock_release(bplib_mpool_lock_t *lock)
+{
+    bplib_os_unlock(lock->lock_id);
+}
+
+/**
+ * @brief Release a given lock and indicate state change
+ *
+ * Unlocks the given resource, and also signals to other threads that state has changed
+ *
+ * Other threads waiting on the same lock are unblocked and will all re-check the condition
+ * they are waiting on.
+ *
+ * @param lock
+ */
+static inline void bplib_mpool_lock_broadcast_release(bplib_mpool_lock_t *lock)
+{
+    bplib_os_broadcast_signal_and_unlock(lock->lock_id);
+}
+
+/**
+ * @brief Prepares for resource-based locking
+ *
+ * Locates the correct lock to use for the given resource, but does not acquire the lock
+ *
+ * @note  it is imperative that all calls use the same referece address (such as the head
+ * of the list) when referring to the same resource for locking to work correctly.
+ *
+ * @param pool
+ * @param resource_addr
+ * @return bplib_mpool_lock_t*
+ */
+bplib_mpool_lock_t *bplib_mpool_lock_prepare(void *resource_addr);
+
+/**
+ * @brief Lock a given resource
+ *
+ * Locates the correct lock to use for a given resource address, and also acquires it
+ *
+ * @note  it is imperative that all calls use the same referece address (such as the head
+ * of the list) when referring to the same resource for locking to work correctly.
+ *
+ * @param pool
+ * @param resource_addr
+ * @return bplib_mpool_lock_t*
+ */
+bplib_mpool_lock_t *bplib_mpool_lock_resource(void *resource_addr);
+
+/**
+ * @brief Waits for a state change related to the given lock
+ *
+ * @note The resource must be locked when called.
+ *
+ * @param lock
+ * @param until_dtntime
+ * @return true
+ * @return false
+ */
+bool bplib_mpool_lock_wait(bplib_mpool_lock_t *lock, uint64_t until_dtntime);
+
 void bplib_mpool_bblock_primary_init(bplib_mpool_bblock_primary_t *pblk);
 void bplib_mpool_bblock_canonical_init(bplib_mpool_bblock_canonical_t *cblk);
-void bplib_mpool_subq_init(bplib_mpool_subq_t *qblk);
+void bplib_mpool_subq_init(bplib_mpool_subq_base_t *qblk);
 void bplib_mpool_flow_init(bplib_mpool_flow_t *fblk);
+
+/**
+ * @brief Append a single bundle to the given queue (flow)
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param subq
+ * @param cpb
+ */
+void bplib_mpool_subq_push_single(bplib_mpool_subq_base_t *subq, bplib_mpool_block_t *cpb);
+
+/**
+ * @brief Get the next bundle from the given queue (flow)
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param subq
+ * @return bplib_mpool_block_t*
+ */
+bplib_mpool_block_t *bplib_mpool_subq_pull_single(bplib_mpool_subq_base_t *subq);
+
+/**
+ * @brief Counts the number of blocks in a list
+ *
+ * For record-keeping or stats-reporting purposes, this counts the number of blocks in a list
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param list the subject list head
+ * @return uint32_t number of blocks
+ */
+uint32_t bplib_mpool_list_count_blocks(bplib_mpool_block_t *list);
+
+/**
+ * @brief Pushes an entire list of blocks into a subq
+ *
+ * Similar to bplib_mpool_subq_move_all() but the source is just a simple list rather
+ * than a subq FIFO object.
+ *
+ * Because simple lists do not track the number of entries, this counts the blocks in the
+ * list prior to moving the items, so the dest queue push stats will remain correct.
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param subq_dst the destination queue
+ * @param list  the source list
+ * @return uint32_t number of blocks moved
+ */
+uint32_t bplib_mpool_subq_merge_list(bplib_mpool_subq_base_t *subq_dst, bplib_mpool_block_t *list);
+
+/**
+ * @brief Merges the entire contents of the source subq into the destination
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param subq_dst
+ * @param subq_src
+ * @return The number of queue entries moved
+ */
+uint32_t bplib_mpool_subq_move_all(bplib_mpool_subq_base_t *subq_dst, bplib_mpool_subq_base_t *subq_src);
+
+/**
+ * @brief Drops the entire contents of a subq
+ *
+ * This purges the contents of a queue, such as when the interface is set to a "down" state,
+ * this removes any pending items that were in it.
+ *
+ * @note This should only be called from internal contexts where a lock is held
+ *
+ * @param pool
+ * @param subq
+ * @return uint32_t The number of queue entries dropped
+ */
+uint32_t bplib_mpool_subq_drop_all(bplib_mpool_t *pool, bplib_mpool_subq_base_t *subq);
 
 bplib_mpool_block_content_t *bplib_mpool_get_block_content(bplib_mpool_block_t *cb);
 bplib_mpool_block_content_t *bplib_mpool_alloc_block_internal(bplib_mpool_t *pool, bplib_mpool_blocktype_t blocktype,


### PR DESCRIPTION
Every queue operation is now protected by a mutex and synchronization, which permits the functionality to be split into multiple threads, such as a maintenance/background task separate from the application.

Fixes #97 