### PR TITLE
Fix #96, implement list search routine

### DIFF
--- a/app/bptest.c
+++ b/app/bptest.c
@@ -440,7 +440,7 @@ int bplib2_bundle_test(void)
     printf("@%lu: waiting for ACK Bundle...\n", (unsigned long)bplib_os_get_dtntime_ms());
 
     bundle_sz  = sizeof(bundle_buffer);
-    lib_status = bplib_cla_egress(s2_rtbl, s2_intf_cla, bundle_buffer, &bundle_sz, 5000);
+    lib_status = bplib_cla_egress(s2_rtbl, s2_intf_cla, bundle_buffer, &bundle_sz, 5000000);
     if (lib_status != 0)
     {
         fprintf(stderr, "Failed bplib_cla_egress() for DACS  code=%d... exiting\n", lib_status);

--- a/common/v7_rbtree.c
+++ b/common/v7_rbtree.c
@@ -1030,6 +1030,17 @@ void bplib_rbt_init_root(bplib_rbt_root_t *tree)
 }
 
 /*--------------------------------------------------------------------------------------
+ * bplib_rbt_is_empty - Checks if the given tree is empty
+ *
+ * tree: A ptr to a bplib_rbt_root_t
+ * returns: true if the tree is empty
+ *--------------------------------------------------------------------------------------*/
+bool bplib_rbt_is_empty(const bplib_rbt_root_t *tree)
+{
+    return (tree->root == NULL);
+}
+
+/*--------------------------------------------------------------------------------------
  * bplib_rbt_is_member - Checks if the given node is a member of the tree
  *
  * tree: A ptr to a bplib_rbt_root_t

--- a/common/v7_rbtree.h
+++ b/common/v7_rbtree.h
@@ -79,6 +79,16 @@ void bplib_rbt_init_root(bplib_rbt_root_t *tree);
 
 /*--------------------------------------------------------------------------------------*/
 /**
+ * @brief Checks if the given tree has any nodes
+ *
+ * @param[in] tree   The tree to check
+ * @return true if the tree is currently empty
+ * @return false if the tree is not currently empty
+ */
+bool bplib_rbt_is_empty(const bplib_rbt_root_t *tree);
+
+/*--------------------------------------------------------------------------------------*/
+/**
  * @brief Checks if the given node is a member of the tree
  *
  * @param[in] tree   The tree to check

--- a/lib/v7_dataservice_api.c
+++ b/lib/v7_dataservice_api.c
@@ -554,22 +554,26 @@ int bplib_dataservice_event_impl(bplib_routetbl_t *rtbl, bplib_mpool_ref_t intf_
     return BP_SUCCESS;
 }
 
-void bplib_dataservice_base_construct(void *arg, bplib_mpool_block_t *blk)
+int bplib_dataservice_base_construct(void *arg, bplib_mpool_block_t *blk)
 {
     bplib_route_serviceintf_info_t *base_intf;
 
     base_intf = bplib_mpool_generic_data_cast(blk, BPLIB_BLOCKTYPE_SERVICE_BASE);
-    if (base_intf != NULL)
+    if (base_intf == NULL)
     {
-        bplib_rbt_init_root(&base_intf->service_index);
+        return BP_ERROR;
     }
+
+    bplib_rbt_init_root(&base_intf->service_index);
+    return BP_SUCCESS;
 }
 
-void bplib_dataservice_block_recycle(void *arg, bplib_mpool_block_t *rblk)
+int bplib_dataservice_block_recycle(void *arg, bplib_mpool_block_t *rblk)
 {
     /* this should check if the block made it to storage or not, and if the calling
      * task in bplib_send() is blocked waiting for the block to be sent, this should
      * release that task. In is a no-op for now until timeouts are implemented. */
+    return BP_SUCCESS;
 }
 
 void bplib_dataservice_init(bplib_mpool_t *pool)

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -98,8 +98,11 @@ typedef enum
  * This is a generic API for a function to handle various events/conditions
  * that occur at the block level.  The generic argument supplies the context
  * information.
+ *
+ * The return value depends on the context and may or may not be used, it
+ * should should return 0 unless otherwise specified.
  */
-typedef void (*bplib_mpool_callback_func_t)(void *, bplib_mpool_block_t *);
+typedef int (*bplib_mpool_callback_func_t)(void *, bplib_mpool_block_t *);
 
 /**
  * @brief Blocktype API
@@ -476,6 +479,21 @@ void bplib_mpool_recycle_all_blocks_in_list(bplib_mpool_t *pool, bplib_mpool_blo
  */
 int bplib_mpool_foreach_item_in_list(bplib_mpool_block_t *list, bool always_remove,
                                      bplib_mpool_callback_func_t callback_fn, void *callback_arg);
+
+/**
+ * @brief Search a list in sequential order
+ *
+ * The match function will be invoked for every entry in the list, and the supplied argument
+ * will be passed to it. If the function returns 0, then the search stops and the node is returned.
+ *
+ * @param list The list to search
+ * @param match_fn A function that should return 0 if a match is found, nonzero otherwise
+ * @param match_arg An opaque argument passed to the match_fn, typically the match reference object
+ * @return bplib_mpool_block_t* The matching list entry
+ * @retval NULL if no match was found
+ */
+bplib_mpool_block_t *bplib_mpool_search_list(const bplib_mpool_block_t *list, bplib_mpool_callback_func_t match_fn,
+                                             void *match_arg);
 
 /**
  * @brief Run basic maintenance on the memory pool

--- a/mpool/inc/v7_mpool_flows.h
+++ b/mpool/inc/v7_mpool_flows.h
@@ -146,6 +146,27 @@ static inline bool bplib_mpool_subq_depthlimit_may_pull(const bplib_mpool_subq_d
 }
 
 /**
+ * @brief Check if given subq is less than half full
+ *
+ * The check is for the "half full" point at which the application should generally stop
+ * adding new entries to the queue, and shift focus toward draining the queue.  At the
+ * half-full point there is still room in the queue so bplib_mpool_subq_depthlimit_try_push()
+ * may still succeed even if this test returns false.
+ *
+ * @note This check is lockless, therefore the state of the subq may change at any time
+ * if other threads/tasks are pushing from the same subq.  Therefore even if this function
+ * returns true, it does not guarantee that a subsequent call to
+ * bplib_mpool_subq_depthlimit_try_push() will succeed.
+ *
+ * @param subq
+ * @retval true if subq is less than half full.
+ */
+static inline bool bplib_mpool_subq_depthlimit_may_push(const bplib_mpool_subq_depthlimit_t *subq)
+{
+    return (bplib_mpool_subq_get_depth(&subq->base_subq) < (subq->current_depth_limit / 2));
+}
+
+/**
  * @brief Mark a given flow as active
  *
  * This marks it so it will be processed during the next call to forward data


### PR DESCRIPTION
Rework the DACS lookup to use a new search routine, which simplifies several routines and allowed for some code consolidation.
This also replaces several foreach calls with list iterators.

Fixes #96 