### PR TITLE
Fix #91, initial implementation of job queues

### DIFF
--- a/app/bptest.c
+++ b/app/bptest.c
@@ -155,7 +155,7 @@ int bplib_route_test(void)
     bp_ipn_addr_t     storage_addr;
 
     /* Test route table with 1MB of cache */
-    rtbl = bplib_route_alloc_table(10, 10, 1 << 20);
+    rtbl = bplib_route_alloc_table(10, 1 << 20);
     if (rtbl == NULL)
     {
         fprintf(stderr, "%s(): bplib_route_alloc_table failed\n", __func__);
@@ -211,7 +211,7 @@ int bplib_route_test(void)
     s1_rtbl = rtbl;
 
     /* Test route table with 1MB of cache */
-    rtbl = bplib_route_alloc_table(10, 10, 1 << 20);
+    rtbl = bplib_route_alloc_table(10, 1 << 20);
     if (rtbl == NULL)
     {
         fprintf(stderr, "%s(): bplib_route_alloc_table failed\n", __func__);
@@ -303,6 +303,9 @@ int bplib2_bundle_test(void)
         bplib_close_socket(desc);
         return -1;
     }
+
+    /* wait for any pending data flows to complete */
+    bplib_route_maintenance_complete_wait(s1_rtbl);
 
     printf("@%lu: Storing payload:\n", (unsigned long)bplib_os_get_dtntime_ms());
     display(stdout, (const uint8_t *)my_payload, 0, sizeof(my_payload));

--- a/common/v7_rbtree.h
+++ b/common/v7_rbtree.h
@@ -85,7 +85,7 @@ void bplib_rbt_init_root(bplib_rbt_root_t *tree);
  * @return true if the tree is currently empty
  * @return false if the tree is not currently empty
  */
-bool bplib_rbt_is_empty(const bplib_rbt_root_t *tree);
+bool bplib_rbt_tree_is_empty(const bplib_rbt_root_t *tree);
 
 /*--------------------------------------------------------------------------------------*/
 /**
@@ -96,7 +96,7 @@ bool bplib_rbt_is_empty(const bplib_rbt_root_t *tree);
  * @return true if the node is currently a member of the specified tree
  * @return false if the node is not currently a member of the specified tree
  */
-bool bplib_rbt_is_member(const bplib_rbt_root_t *tree, const bplib_rbt_link_t *node);
+bool bplib_rbt_node_is_member(const bplib_rbt_root_t *tree, const bplib_rbt_link_t *node);
 
 /*--------------------------------------------------------------------------------------*/
 /**

--- a/inc/bplib_api_types.h
+++ b/inc/bplib_api_types.h
@@ -80,7 +80,7 @@ struct bp_desc;
 typedef struct bp_desc           bp_desc_t;
 typedef struct bp_socket         bp_socket_t;
 typedef struct bplib_mpool_block bplib_mpool_block_t;
-typedef struct mpool             bplib_mpool_t;
+typedef struct bplib_mpool       bplib_mpool_t;
 
 /**
  * @brief Type of block CRC calculated by bplib
@@ -262,6 +262,12 @@ static inline bp_handle_t bp_handle_from_serial(int hv, bp_handle_t base)
     (bp_handle_t)              \
     {                          \
         0x5000000              \
+    }
+
+#define BPLIB_HANDLE_MPOOL_BASE \
+    (bp_handle_t)               \
+    {                           \
+        0x6000000               \
     }
 
 #ifdef __cplusplus

--- a/inc/bplib_routing.h
+++ b/inc/bplib_routing.h
@@ -28,55 +28,15 @@
 #include <stdint.h>
 #include "bplib_api_types.h"
 #include "v7_mpool.h"
+#include "v7_mpool_flows.h"
 
-#define BPLIB_INTF_STATE_ADMIN_UP 0x01
-#define BPLIB_INTF_STATE_OPER_UP  0x02
-#define BPLIB_INTF_STATE_STORAGE  0x04
-
-#define BPLIB_INTF_STATE_ALL_FLAGS 0x07
+#define BPLIB_INTF_STATE_ADMIN_UP BPLIB_MPOOL_FLOW_FLAGS_ADMIN_UP
+#define BPLIB_INTF_STATE_OPER_UP  BPLIB_MPOOL_FLOW_FLAGS_OPER_UP
+#define BPLIB_INTF_STATE_STORAGE  BPLIB_MPOOL_FLOW_FLAGS_STORAGE
 
 /******************************************************************************
  TYPEDEFS
  ******************************************************************************/
-
-/*
- * Enumeration that defines the various possible routing table events.  This enum
- * must always appear first in the structure that is the argument to the event handler,
- * and indicates the actual event that has occurred
- */
-typedef enum
-{
-    bplib_event_type_undefined,
-    bplib_event_type_poll_interval,
-    bplib_event_type_attach_subintf,
-    bplib_event_type_remove_subintf,
-    bplib_event_type_interface_up,
-    bplib_event_type_interface_down,
-    bplib_event_type_route_up,
-    bplib_event_type_route_down,
-    bplib_event_type_max
-
-} bplib_event_type_t;
-
-typedef struct bplib_route_state_event
-{
-    bplib_event_type_t event_type; /* must be first */
-    bp_ipn_t           dest;
-    bp_ipn_t           mask;
-} bplib_route_state_event_t;
-
-typedef struct bplib_intf_state_event
-{
-    bplib_event_type_t event_type; /* must be first */
-    bp_handle_t        intf_id;
-} bplib_intf_state_event_t;
-
-typedef union bplib_generic_event
-{
-    bplib_event_type_t        event_type;
-    bplib_intf_state_event_t  intf_state;
-    bplib_route_state_event_t route_state;
-} bplib_generic_event_t;
 
 typedef int (*bplib_route_action_func_t)(bplib_routetbl_t *tbl, bplib_mpool_ref_t ref, void *arg);
 
@@ -88,25 +48,25 @@ typedef int (*bplib_route_action_func_t)(bplib_routetbl_t *tbl, bplib_mpool_ref_
  EXPORTED FUNCTIONS
  ******************************************************************************/
 
-bplib_routetbl_t *bplib_route_alloc_table(uint32_t max_routes, uint32_t max_intfs, size_t cache_mem_size);
+bplib_routetbl_t *bplib_route_alloc_table(uint32_t max_routes, size_t cache_mem_size);
 bplib_mpool_t    *bplib_route_get_mpool(const bplib_routetbl_t *tbl);
 
 bp_handle_t bplib_route_register_generic_intf(bplib_routetbl_t *tbl, bp_handle_t parent_intf_id,
-                                              bplib_mpool_ref_t blkref);
+                                              bplib_mpool_block_t *flow_block);
 
 void bplib_route_ingress_route_single_bundle(bplib_routetbl_t *tbl, bplib_mpool_block_t *pblk);
-int  bplib_route_ingress_baseintf_forwarder(bplib_routetbl_t *tbl, bplib_mpool_ref_t flow_ref, void *forward_arg);
-int  bplib_route_ingress_to_parent(bplib_routetbl_t *tbl, bplib_mpool_ref_t flow_ref, void *ingress_arg);
+int  bplib_route_ingress_baseintf_forwarder(void *arg, bplib_mpool_block_t *subq_src);
+int  bplib_route_ingress_to_parent(void *arg, bplib_mpool_block_t *subq_src);
 
 bp_handle_t       bplib_route_bind_sub_intf(bplib_mpool_block_t *flow_block, bp_handle_t parent_intf_id);
 bplib_mpool_ref_t bplib_route_get_intf_controlblock(bplib_routetbl_t *tbl, bp_handle_t intf_id);
 void              bplib_route_release_intf_controlblock(bplib_routetbl_t *tbl, bplib_mpool_ref_t refptr);
 
 int bplib_route_register_forward_ingress_handler(bplib_routetbl_t *tbl, bp_handle_t intf_id,
-                                                 bplib_route_action_func_t ingress, void *ingress_arg);
+                                                 bplib_mpool_callback_func_t ingress);
 int bplib_route_register_forward_egress_handler(bplib_routetbl_t *tbl, bp_handle_t intf_id,
-                                                bplib_route_action_func_t egress, void *egress_arg);
-int bplib_route_register_event_handler(bplib_routetbl_t *tbl, bp_handle_t intf_id, bplib_route_action_func_t event);
+                                                bplib_mpool_callback_func_t egress);
+int bplib_route_register_event_handler(bplib_routetbl_t *tbl, bp_handle_t intf_id, bplib_mpool_callback_func_t event);
 
 int         bplib_route_del_intf(bplib_routetbl_t *tbl, bp_handle_t intf_id);
 bp_handle_t bplib_route_get_next_intf_with_flags(const bplib_routetbl_t *tbl, bp_ipn_t dest, uint32_t req_flags,

--- a/mpool/CMakeLists.txt
+++ b/mpool/CMakeLists.txt
@@ -10,6 +10,7 @@
 add_library(bplib_mpool OBJECT
     src/v7_mpool.c
     src/v7_mpool_ref.c
+    src/v7_mpool_job.c
     src/v7_mpool_bblocks.c
     src/v7_mpool_flows.c
     src/v7_mpstream.c

--- a/mpool/inc/v7_mpool_bblocks.h
+++ b/mpool/inc/v7_mpool_bblocks.h
@@ -245,7 +245,7 @@ bplib_mpool_block_t *bplib_mpool_bblock_primary_locate_canonical(bplib_mpool_bbl
  * @param pool
  * @param cpb
  */
-void bplib_mpool_bblock_primary_drop_encode(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb);
+void bplib_mpool_bblock_primary_drop_encode(bplib_mpool_bblock_primary_t *cpb);
 
 /**
  * @brief Drop all encode data (CBOR) from a canonical block
@@ -256,7 +256,7 @@ void bplib_mpool_bblock_primary_drop_encode(bplib_mpool_t *pool, bplib_mpool_bbl
  * @param pool
  * @param ccb
  */
-void bplib_mpool_bblock_canonical_drop_encode(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb);
+void bplib_mpool_bblock_canonical_drop_encode(bplib_mpool_bblock_canonical_t *ccb);
 
 /**
  * @brief Copy an entire chain of encoded blocks to a target buffer

--- a/mpool/inc/v7_mpool_job.h
+++ b/mpool/inc/v7_mpool_job.h
@@ -1,0 +1,80 @@
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
+ *
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef V7_MPOOL_JOB_H
+#define V7_MPOOL_JOB_H
+
+#include <string.h>
+
+#include "v7_mpool.h"
+
+typedef struct bplib_mpool_job
+{
+    bplib_mpool_block_t         link;
+    bplib_mpool_callback_func_t handler;
+} bplib_mpool_job_t;
+
+typedef struct bplib_mpool_job_statechange
+{
+    bplib_mpool_job_t base_job;
+
+    /* JPHFIX: this single event handler may be separated into per-event-type handlers */
+    bplib_mpool_callback_func_t event_handler;
+} bplib_mpool_job_statechange_t;
+
+/**
+ * @brief Cast a block to a job type
+ *
+ * @param cb
+ * @return bplib_mpool_job_t*
+ */
+bplib_mpool_job_t *bplib_mpool_job_cast(bplib_mpool_block_t *cb);
+
+void bplib_mpool_job_init(bplib_mpool_block_t *base_block, bplib_mpool_job_t *jblk);
+
+/**
+ * @brief Mark a given job as runnable
+ *
+ * This marks it so it will be processed during the next call to forward data
+ *
+ * @note This is handled automatically by functions which append to a flow subq, such
+ * as bplib_mpool_flow_try_push() and bplib_mpool_flow_try_move_all().
+ * Applictions only need to explicitly call this API to mark it as active if there is
+ * some other factor that requires it to be processed again.
+ *
+ * @param pool
+ * @param jblk Job that is ready to run
+ */
+void bplib_mpool_job_mark_active(bplib_mpool_job_t *job);
+
+/**
+ * @brief Get the next active flow in the pool
+ *
+ * The given callback function will be invoked for all flows which are
+ * currently marked as active
+ *
+ * @param pool
+ * @return bplib_mpool_job_t *
+ */
+bplib_mpool_job_t *bplib_mpool_job_get_next_active(bplib_mpool_t *pool);
+
+void bplib_mpool_job_run_all(bplib_mpool_t *pool, void *arg);
+
+#endif /* V7_MPOOL_JOB_H */

--- a/mpool/inc/v7_mpool_ref.h
+++ b/mpool/inc/v7_mpool_ref.h
@@ -59,7 +59,7 @@ static inline bplib_mpool_block_t *bplib_mpool_dereference(bplib_mpool_ref_t ref
  * @param blk
  * @return bplib_mpool_ref_t*
  */
-bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_t *pool, bplib_mpool_block_t *blk);
+bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_block_t *blk);
 
 bplib_mpool_ref_t bplib_mpool_ref_duplicate(bplib_mpool_ref_t refptr);
 bplib_mpool_ref_t bplib_mpool_ref_from_block(bplib_mpool_block_t *rblk);
@@ -76,7 +76,7 @@ bplib_mpool_ref_t bplib_mpool_ref_from_block(bplib_mpool_block_t *rblk);
  * @param pool
  * @param refptr
  */
-void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr);
+void bplib_mpool_ref_release(bplib_mpool_ref_t refptr);
 
 /**
  * @brief Creates a separate block reference to the data block
@@ -96,7 +96,6 @@ void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr);
  * @param init_arg Opaque pointer to pass to initializer (may be NULL)
  * @return bplib_mpool_block_t*
  */
-bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_t *pool, bplib_mpool_ref_t refptr, uint32_t magic_number,
-                                                void *init_arg);
+bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_ref_t refptr, uint32_t magic_number, void *init_arg);
 
 #endif /* V7_MPOOL_REF_H */

--- a/mpool/src/v7_mpool_job.c
+++ b/mpool/src/v7_mpool_job.c
@@ -1,0 +1,166 @@
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
+ *
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file
+ *
+ * @brief Contains the memory pool implementation for blocks representing
+ * flows of bundles (ingress and egress queue).
+ *
+ */
+
+#include <string.h>
+#include <assert.h>
+
+#include "bplib.h"
+#include "bplib_os.h"
+#include "v7_mpool_internal.h"
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_init
+ *
+ *-----------------------------------------------------------------*/
+void bplib_mpool_job_init(bplib_mpool_block_t *base_block, bplib_mpool_job_t *jblk)
+{
+    bplib_mpool_init_secondary_link(base_block, &jblk->link, bplib_mpool_blocktype_job);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_cast
+ *
+ *-----------------------------------------------------------------*/
+bplib_mpool_job_t *bplib_mpool_job_cast(bplib_mpool_block_t *cb)
+{
+    if (cb != NULL && cb->type == bplib_mpool_blocktype_job)
+    {
+        return (bplib_mpool_job_t *)cb;
+    }
+
+    return NULL;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_cancel_internal
+ *
+ *-----------------------------------------------------------------*/
+void bplib_mpool_job_cancel_internal(bplib_mpool_job_t *job)
+{
+    assert(job->link.type == bplib_mpool_blocktype_job);
+    bplib_mpool_extract_node(&job->link);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_mark_active_internal
+ *
+ *-----------------------------------------------------------------*/
+void bplib_mpool_job_mark_active_internal(bplib_mpool_block_t *active_list, bplib_mpool_job_t *job)
+{
+    /* first cancel the job it if it was already active */
+    /* this permits it to be marked as active multiple times, it will still only be in the runnable list once */
+    bplib_mpool_job_cancel_internal(job);
+    if (job->handler)
+    {
+        bplib_mpool_insert_before(active_list, &job->link);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_mark_active
+ *
+ *-----------------------------------------------------------------*/
+void bplib_mpool_job_mark_active(bplib_mpool_job_t *job)
+{
+    bplib_mpool_lock_t                *lock;
+    bplib_mpool_block_admin_content_t *admin;
+    bplib_mpool_t                     *pool;
+
+    pool  = bplib_mpool_get_parent_pool_from_link(&job->link);
+    admin = bplib_mpool_get_admin(pool);
+
+    lock = bplib_mpool_lock_resource(pool);
+    bplib_mpool_job_mark_active_internal(&admin->active_list, job);
+    bplib_mpool_lock_release(lock);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_mpool_job_get_next_active
+ *
+ *-----------------------------------------------------------------*/
+bplib_mpool_job_t *bplib_mpool_job_get_next_active(bplib_mpool_t *pool)
+{
+    bplib_mpool_job_t                 *job;
+    bplib_mpool_lock_t                *lock;
+    bplib_mpool_block_t               *jblk;
+    bplib_mpool_block_admin_content_t *admin;
+
+    admin = bplib_mpool_get_admin(pool);
+
+    do
+    {
+        lock = bplib_mpool_lock_resource(pool);
+
+        /* if the head is reached here, then the list is empty */
+        jblk = bplib_mpool_get_next_block(&admin->active_list);
+        if (bplib_mpool_is_list_head(jblk))
+        {
+            jblk = NULL;
+        }
+        else
+        {
+            bplib_mpool_extract_node(jblk);
+        }
+        bplib_mpool_lock_release(lock);
+
+        job = bplib_mpool_job_cast(jblk);
+    }
+    while (job == NULL && jblk != NULL);
+
+    return job;
+}
+
+void bplib_mpool_job_run_all(bplib_mpool_t *pool, void *arg)
+{
+    bplib_mpool_job_t *job;
+
+    /* forward any bundles between interfaces, based on active flow list */
+    while (true)
+    {
+        job = bplib_mpool_job_get_next_active(pool);
+        if (job == NULL)
+        {
+            break;
+        }
+
+        /* note it may not be necessary to call this _every_ cycle, this could be
+         * deferred to a lower priority task if necessary, but this will be sure to get it done */
+        bplib_mpool_maintain(pool);
+
+        if (job->handler != NULL)
+        {
+            job->handler(arg, &job->link);
+        }
+    }
+}

--- a/mpool/src/v7_mpool_ref.c
+++ b/mpool/src/v7_mpool_ref.c
@@ -45,12 +45,12 @@ bplib_mpool_ref_t bplib_mpool_ref_duplicate(bplib_mpool_ref_t refptr)
      * or it should have been garbage-collected already, so something is broken.
      */
 
-    lock = bplib_mpool_lock_resource(refptr);
+    lock = bplib_mpool_lock_resource(&refptr->header.base_link);
     assert(refptr->header.refcount > 0);
     ++refptr->header.refcount;
     bplib_mpool_lock_release(lock);
 
-    return (bplib_mpool_ref_t)refptr;
+    return refptr;
 }
 
 /*----------------------------------------------------------------
@@ -58,11 +58,10 @@ bplib_mpool_ref_t bplib_mpool_ref_duplicate(bplib_mpool_ref_t refptr)
  * Function: bplib_mpool_ref_create
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_t *pool, bplib_mpool_block_t *blk)
+bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_block_t *blk)
 {
     bplib_mpool_block_content_t *content;
     bplib_mpool_lock_t          *lock;
-    bool                         is_first_ref;
 
     /*
      * This drills down to the actual base object (the "root" so to speak), so that the
@@ -70,29 +69,15 @@ bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_t *pool, bplib_mpool_block_
      * allow for a double-ref situation - although the data model does allow for that, this
      * does not create a "ref-to-ref" at the moment.  TBD if that is useful or not...
      */
-    content = (bplib_mpool_block_content_t *)bplib_mpool_obtain_base_block(blk);
+    content = bplib_mpool_block_dereference_content(blk);
     if (content == NULL)
     {
         return NULL;
     }
 
-    lock         = bplib_mpool_lock_resource(content);
-    is_first_ref = (content->header.refcount == 0);
+    lock = bplib_mpool_lock_resource(content);
     ++content->header.refcount;
     bplib_mpool_lock_release(lock);
-
-    /*
-     * If the refcount is 0, that means this is still a regular (non-refcounted) object.
-     * If nonzero then it is already a recounted object
-     */
-    if (is_first_ref)
-    {
-        /* The original object goes into the active list in the pool, and becomes "owned"
-         * by the pool after this.  It should no longer be directly used by the caller. */
-        lock = bplib_mpool_lock_resource(pool);
-        bplib_mpool_insert_before(&pool->managed_block_list, blk);
-        bplib_mpool_lock_release(lock);
-    }
 
     return content;
 }
@@ -102,11 +87,15 @@ bplib_mpool_ref_t bplib_mpool_ref_create(bplib_mpool_t *pool, bplib_mpool_block_
  * Function: bplib_mpool_ref_make_block
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_t *pool, bplib_mpool_ref_t refptr, uint32_t magic_number,
-                                                void *init_arg)
+bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_ref_t refptr, uint32_t magic_number, void *init_arg)
 {
     bplib_mpool_block_content_t *rblk;
+    bplib_mpool_block_content_t *bblk;
     bplib_mpool_lock_t          *lock;
+    bplib_mpool_t               *pool;
+
+    bblk = bplib_mpool_block_dereference_content(bplib_mpool_dereference(refptr));
+    pool = bplib_mpool_get_parent_pool_from_link(&bblk->header.base_link);
 
     lock = bplib_mpool_lock_resource(pool);
     rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg);
@@ -117,7 +106,7 @@ bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_t *pool, bplib_mpool
         return NULL;
     }
 
-    rblk->u.ref.pref_target = bplib_mpool_ref_duplicate(refptr);
+    rblk->u.ref.pref_target = bplib_mpool_ref_duplicate(bblk);
 
     return (bplib_mpool_block_t *)rblk;
 }
@@ -146,7 +135,7 @@ bplib_mpool_ref_t bplib_mpool_ref_from_block(bplib_mpool_block_t *rblk)
  * Function: bplib_mpool_ref_release
  *
  *-----------------------------------------------------------------*/
-void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr)
+void bplib_mpool_ref_release(bplib_mpool_ref_t refptr)
 {
     bplib_mpool_block_header_t *block_hdr;
     bplib_mpool_lock_t         *lock;
@@ -170,7 +159,9 @@ void bplib_mpool_ref_release(bplib_mpool_t *pool, bplib_mpool_ref_t refptr)
 
         if (needs_recycle)
         {
-            bplib_mpool_recycle_block(pool, &block_hdr->base_link);
+            /* it should not be part of a list at this point */
+            assert(bplib_mpool_is_link_unattached(&block_hdr->base_link));
+            bplib_mpool_recycle_block(&block_hdr->base_link);
         }
     }
 }

--- a/mpool/src/v7_mpstream.c
+++ b/mpool/src/v7_mpstream.c
@@ -36,7 +36,7 @@ void bplib_mpool_start_stream_init(bplib_mpool_stream_t *mps, bplib_mpool_t *poo
 {
     memset(mps, 0, sizeof(*mps));
 
-    bplib_mpool_init_list_head(&mps->head);
+    bplib_mpool_init_list_head(NULL, &mps->head);
 
     mps->dir       = dir;
     mps->pool      = pool;
@@ -207,7 +207,7 @@ size_t bplib_mpool_stream_seek(bplib_mpool_stream_t *mps, size_t target_position
 
             if (mps->dir == bplib_mpool_stream_dir_write)
             {
-                bplib_mpool_recycle_block(mps->pool, mps->last_eblk);
+                bplib_mpool_recycle_block(mps->last_eblk);
                 mps->curr_limit = bplib_mpool_get_generic_data_capacity(next_block);
                 mps->curr_pos   = bplib_mpool_get_generic_data_capacity(next_block);
             }

--- a/v7/inc/v7_codec.h
+++ b/v7/inc/v7_codec.h
@@ -35,9 +35,9 @@
  * can be assumed canonical.  Payload of the bundle will be recorded as an offset and size into that block, there
  * is no separate output.
  */
-int v7_block_decode_pri(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb, const void *data_ptr, size_t data_size);
-int v7_block_decode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr,
-                              size_t data_size, bp_blocktype_t payload_block_hint);
+int v7_block_decode_pri(bplib_mpool_bblock_primary_t *cpb, const void *data_ptr, size_t data_size);
+int v7_block_decode_canonical(bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr, size_t data_size,
+                              bp_blocktype_t payload_block_hint);
 
 /*
  * On the encode side of things, the block types are known ahead of time.  Encoding of a payload block is separate
@@ -46,14 +46,13 @@ int v7_block_decode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_
  * One possible option would be to pass in NULL/0 for the block types that do not have separate data, to keep the APIs
  * more consistent.
  */
-int v7_block_encode_pri(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb);
-int v7_block_encode_pay(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr,
-                        size_t data_size);
+int v7_block_encode_pri(bplib_mpool_bblock_primary_t *cpb);
+int v7_block_encode_pay(bplib_mpool_bblock_canonical_t *ccb, const void *data_ptr, size_t data_size);
 
-int v7_block_encode_canonical(bplib_mpool_t *pool, bplib_mpool_bblock_canonical_t *ccb);
+int v7_block_encode_canonical(bplib_mpool_bblock_canonical_t *ccb);
 
-size_t v7_compute_full_bundle_size(bplib_mpool_t *pool, bplib_mpool_bblock_primary_t *cpb);
+size_t v7_compute_full_bundle_size(bplib_mpool_bblock_primary_t *cpb);
 size_t v7_copy_full_bundle_out(bplib_mpool_bblock_primary_t *cpb, void *buffer, size_t buf_sz);
-size_t v7_copy_full_bundle_in(bplib_mpool_t *pool, bplib_mpool_block_t **pblk_out, const void *buffer, size_t buf_sz);
+size_t v7_copy_full_bundle_in(bplib_mpool_bblock_primary_t *cpb, const void *buffer, size_t buf_sz);
 
 #endif /* V7_CODEC_H */


### PR DESCRIPTION
Contains several enhancements to make work queues more abstract and easier to manage.*

This also enhances the bplib_mpool_block_t structure such that every instance of this structure is traceable back to its parent block as well as the pool it originally came from.  This alleviates the need to pass the pool pointer separately on many APIs, simplifying things.

Introduces another block type for a "job" which is abstracted to represent any schedulable item.  This was formerly only for flows,
but now can be used for any purpose.  State changes of interfaces are now handled through this method.

Fixes #91 

**Note:** a follow on work item will need to be added, because this still does not adequately throttle back the sending of bundles based on the CLA/Application willingness to accept them, which is the ultimate goal.