### PR TITLE
Fix #105, allow duplicate keys in rbtree

### DIFF
--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -438,6 +438,20 @@ bplib_mpool_t *bplib_mpool_get_parent_pool_from_link(bplib_mpool_block_t *cb);
 void *bplib_mpool_generic_data_cast(bplib_mpool_block_t *cb, uint32_t required_magic);
 
 /**
+ * @brief Cast a generic user data segment to its parent block
+ *
+ * This is the inverse of bplib_mpool_generic_data_cast() and allows obtaining the pool
+ * block from a generic data pointer.  The pointer passed in must be from a prior call
+ * to bplib_mpool_generic_data_cast() or else the result is undefined.
+ *
+ * @param blk pointer from previous call to bplib_mpool_generic_data_cast
+ * @param required_magic
+ * @return bplib_mpool_generic_data_t*
+ */
+bplib_mpool_block_t *bplib_mpool_generic_data_uncast(void *blk, bplib_mpool_blocktype_t parent_bt,
+                                                     uint32_t required_magic);
+
+/**
  * @brief Gets the size of the user buffer associated with a data block
  *
  * For a CBOR block this is the length of the CBOR data within this block.  For a user

--- a/v7/inc/v7.h
+++ b/v7/inc/v7.h
@@ -41,6 +41,19 @@ bp_dtntime_t v7_get_current_time(void);
 void         v7_set_eid(bp_endpointid_buffer_t *eid, const bp_ipn_addr_t *bp_addr);
 void         v7_get_eid(bp_ipn_addr_t *bp_addr, const bp_endpointid_buffer_t *eid);
 
+static inline int v7_compare_numeric(bp_val_t n1, bp_val_t n2)
+{
+    if (n1 == n2)
+    {
+        return 0;
+    }
+    if (n1 > n2)
+    {
+        return 1;
+    }
+    return -1;
+}
+
 /* A generic strcmp-like call to compare an IPN address to a BP endpoint ID value */
 int v7_compare_ipn2eid(const bp_ipn_addr_t *ipn, const bp_endpointid_buffer_t *eid);
 /* A generic strcmp-like call to compare two IPN addresses */

--- a/v7/src/v7.c
+++ b/v7/src/v7.c
@@ -79,30 +79,17 @@ void v7_get_eid(bp_ipn_addr_t *bp_addr, const bp_endpointid_buffer_t *eid)
     }
 }
 
-static inline int v7_compare_ipn_number(bp_ipn_t n1, bp_ipn_t n2)
-{
-    if (n1 == n2)
-    {
-        return 0;
-    }
-    if (n1 > n2)
-    {
-        return 1;
-    }
-    return -1;
-}
-
 int v7_compare_ipn2eid(const bp_ipn_addr_t *ipn, const bp_endpointid_buffer_t *eid)
 {
     int result;
 
-    result = v7_compare_ipn_number(eid->scheme, bp_endpointid_scheme_ipn);
+    result = v7_compare_numeric(eid->scheme, bp_endpointid_scheme_ipn);
     if (result == 0)
     {
-        result = v7_compare_ipn_number(ipn->node_number, eid->ssp.ipn.node_number);
+        result = v7_compare_numeric(ipn->node_number, eid->ssp.ipn.node_number);
         if (result == 0)
         {
-            result = v7_compare_ipn_number(ipn->service_number, eid->ssp.ipn.service_number);
+            result = v7_compare_numeric(ipn->service_number, eid->ssp.ipn.service_number);
         }
     }
 
@@ -113,10 +100,10 @@ int v7_compare_ipn2ipn(const bp_ipn_addr_t *ipn1, const bp_ipn_addr_t *ipn2)
 {
     int result;
 
-    result = v7_compare_ipn_number(ipn1->node_number, ipn2->node_number);
+    result = v7_compare_numeric(ipn1->node_number, ipn2->node_number);
     if (result == 0)
     {
-        result = v7_compare_ipn_number(ipn1->service_number, ipn2->service_number);
+        result = v7_compare_numeric(ipn1->service_number, ipn2->service_number);
     }
 
     return result;


### PR DESCRIPTION
Rework the rbtree to allow multiple entries with the same key.  This significantly simplifes the cache storage by not requiring a list on each tree entry to handle duplicates.

Fixes #105