### PR TITLE
Fix #110, support extension objects on bundle blocks

### DIFF
--- a/cache/src/v7_cache_custody.c
+++ b/cache/src/v7_cache_custody.c
@@ -31,7 +31,7 @@ void bplib_cache_custody_insert_tracking_block(bplib_cache_state_t *state, bplib
 {
     bplib_mpool_bblock_canonical_t *custody_block;
 
-    custody_info->cblk = bplib_mpool_bblock_canonical_alloc(bplib_cache_parent_pool(state));
+    custody_info->cblk = bplib_mpool_bblock_canonical_alloc(bplib_cache_parent_pool(state), 0, NULL);
     if (custody_info->cblk != NULL)
     {
         bplib_mpool_bblock_primary_append(pri_block, custody_info->cblk);
@@ -151,7 +151,7 @@ bplib_mpool_ref_t bplib_cache_custody_create_dacs(bplib_cache_state_t           
 
     do
     {
-        pblk      = bplib_mpool_bblock_primary_alloc(ppool);
+        pblk      = bplib_mpool_bblock_primary_alloc(ppool, 0, NULL);
         pri_block = bplib_mpool_bblock_primary_cast(pblk);
         if (pri_block == NULL)
         {
@@ -177,7 +177,7 @@ bplib_mpool_ref_t bplib_cache_custody_create_dacs(bplib_cache_state_t           
         pri->crctype                      = bp_crctype_CRC16;
 
         /* Add Payload Block */
-        cblk    = bplib_mpool_bblock_canonical_alloc(ppool);
+        cblk    = bplib_mpool_bblock_canonical_alloc(ppool, 0, NULL);
         c_block = bplib_mpool_bblock_canonical_cast(cblk);
         if (c_block == NULL)
         {

--- a/lib/v7_cla_api.c
+++ b/lib/v7_cla_api.c
@@ -106,8 +106,8 @@ int bplib_generic_bundle_ingress(bplib_mpool_ref_t flow_ref, const void *content
     }
     else
     {
-        pblk =
-            bplib_mpool_bblock_primary_alloc(bplib_mpool_get_parent_pool_from_link(bplib_mpool_dereference(flow_ref)));
+        pblk = bplib_mpool_bblock_primary_alloc(
+            bplib_mpool_get_parent_pool_from_link(bplib_mpool_dereference(flow_ref)), 0, NULL);
         if (pblk != NULL)
         {
             imported_sz = v7_copy_full_bundle_in(bplib_mpool_bblock_primary_cast(pblk), content, size);

--- a/lib/v7_dataservice_api.c
+++ b/lib/v7_dataservice_api.c
@@ -98,7 +98,7 @@ bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_
 
     do
     {
-        pblk      = bplib_mpool_bblock_primary_alloc(pool);
+        pblk      = bplib_mpool_bblock_primary_alloc(pool, 0, NULL);
         pri_block = bplib_mpool_bblock_primary_cast(pblk);
         if (pri_block == NULL)
         {
@@ -136,7 +136,7 @@ bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_
         }
 
         /* Update Payload Block */
-        cblk    = bplib_mpool_bblock_canonical_alloc(pool);
+        cblk    = bplib_mpool_bblock_canonical_alloc(pool, 0, NULL);
         ccb_pay = bplib_mpool_bblock_canonical_cast(cblk);
         if (ccb_pay == NULL)
         {

--- a/mpool/inc/v7_mpool_bblocks.h
+++ b/mpool/inc/v7_mpool_bblocks.h
@@ -199,7 +199,7 @@ void bplib_mpool_bblock_cbor_set_size(bplib_mpool_block_t *cb, size_t user_conte
  * @param pool
  * @return bplib_mpool_block_t*
  */
-bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool);
+bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg);
 
 /**
  * @brief Allocate a new canonical block
@@ -207,7 +207,7 @@ bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool);
  * @param pool
  * @return bplib_mpool_block_t*
  */
-bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool);
+bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg);
 
 /**
  * @brief Allocate a new CBOR data block

--- a/mpool/src/v7_mpool.c
+++ b/mpool/src/v7_mpool.c
@@ -216,16 +216,44 @@ bplib_mpool_block_content_t *bplib_mpool_block_dereference_content(bplib_mpool_b
 
 /*----------------------------------------------------------------
  *
+ * Function: bplib_mpool_get_user_data_offset_by_blocktype
+ *
+ *-----------------------------------------------------------------*/
+size_t bplib_mpool_get_user_data_offset_by_blocktype(bplib_mpool_blocktype_t bt)
+{
+    static const size_t USER_DATA_START_OFFSET[bplib_mpool_blocktype_max] = {
+        [bplib_mpool_blocktype_undefined] = SIZE_MAX,
+        [bplib_mpool_blocktype_api]       = MPOOL_GET_BUFFER_USER_START_OFFSET(api),
+        [bplib_mpool_blocktype_generic]   = MPOOL_GET_BUFFER_USER_START_OFFSET(generic_data),
+        [bplib_mpool_blocktype_primary]   = MPOOL_GET_BUFFER_USER_START_OFFSET(primary),
+        [bplib_mpool_blocktype_canonical] = MPOOL_GET_BUFFER_USER_START_OFFSET(canonical),
+        [bplib_mpool_blocktype_flow]      = MPOOL_GET_BUFFER_USER_START_OFFSET(flow),
+        [bplib_mpool_blocktype_ref]       = MPOOL_GET_BUFFER_USER_START_OFFSET(ref)};
+
+    if (bt >= bplib_mpool_blocktype_max)
+    {
+        return SIZE_MAX;
+    }
+
+    return USER_DATA_START_OFFSET[bt];
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: bplib_mpool_get_generic_data_capacity
  *
  *-----------------------------------------------------------------*/
 size_t bplib_mpool_get_generic_data_capacity(const bplib_mpool_block_t *cb)
 {
-    if (!bplib_mpool_is_generic_data_block(cb))
+    size_t data_offset;
+
+    data_offset = bplib_mpool_get_user_data_offset_by_blocktype(cb->type);
+    if (data_offset > sizeof(bplib_mpool_block_buffer_t))
     {
         return 0;
     }
-    return MPOOL_GET_BLOCK_USER_CAPACITY(generic_data);
+
+    return sizeof(bplib_mpool_block_buffer_t) - data_offset;
 }
 
 /*----------------------------------------------------------------
@@ -358,30 +386,6 @@ size_t bplib_mpool_read_refcount(const bplib_mpool_block_t *cb)
         return block->header.refcount;
     }
     return 0;
-}
-
-/*----------------------------------------------------------------
- *
- * Function: bplib_mpool_get_user_data_offset_by_blocktype
- *
- *-----------------------------------------------------------------*/
-size_t bplib_mpool_get_user_data_offset_by_blocktype(bplib_mpool_blocktype_t bt)
-{
-    static const size_t USER_DATA_START_OFFSET[bplib_mpool_blocktype_max] = {
-        [bplib_mpool_blocktype_undefined] = SIZE_MAX,
-        [bplib_mpool_blocktype_api]       = MPOOL_GET_BUFFER_USER_START_OFFSET(api),
-        [bplib_mpool_blocktype_generic]   = MPOOL_GET_BUFFER_USER_START_OFFSET(generic_data),
-        [bplib_mpool_blocktype_primary]   = MPOOL_GET_BUFFER_USER_START_OFFSET(primary),
-        [bplib_mpool_blocktype_canonical] = MPOOL_GET_BUFFER_USER_START_OFFSET(canonical),
-        [bplib_mpool_blocktype_flow]      = MPOOL_GET_BUFFER_USER_START_OFFSET(flow),
-        [bplib_mpool_blocktype_ref]       = MPOOL_GET_BUFFER_USER_START_OFFSET(ref)};
-
-    if (bt >= bplib_mpool_blocktype_max)
-    {
-        return SIZE_MAX;
-    }
-
-    return USER_DATA_START_OFFSET[bt];
 }
 
 /*----------------------------------------------------------------

--- a/mpool/src/v7_mpool_bblocks.c
+++ b/mpool/src/v7_mpool_bblocks.c
@@ -122,13 +122,13 @@ void bplib_mpool_bblock_canonical_init(bplib_mpool_block_t *base_block, bplib_mp
  * Function: bplib_mpool_bblock_primary_alloc
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
+bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg)
 {
     bplib_mpool_block_content_t *result;
     bplib_mpool_lock_t          *lock;
 
     lock   = bplib_mpool_lock_resource(pool);
-    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary, 0, NULL);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_primary, magic_number, init_arg);
     bplib_mpool_lock_release(lock);
 
     return (bplib_mpool_block_t *)result;
@@ -139,13 +139,13 @@ bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool)
  * Function: bplib_mpool_bblock_canonical_alloc
  *
  *-----------------------------------------------------------------*/
-bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool)
+bplib_mpool_block_t *bplib_mpool_bblock_canonical_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg)
 {
     bplib_mpool_block_content_t *result;
     bplib_mpool_lock_t          *lock;
 
     lock   = bplib_mpool_lock_resource(pool);
-    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical, 0, NULL);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_canonical, magic_number, init_arg);
     bplib_mpool_lock_release(lock);
 
     return (bplib_mpool_block_t *)result;

--- a/store/file_offload.c
+++ b/store/file_offload.c
@@ -306,7 +306,7 @@ static bplib_mpool_block_t *bplib_file_offload_read_blocks(int fd, bplib_file_of
 
     cblk    = NULL;
     c_block = NULL;
-    pblk    = bplib_mpool_bblock_primary_alloc(pool);
+    pblk    = bplib_mpool_bblock_primary_alloc(pool, 0, NULL);
     if (pblk != NULL)
     {
         pri_block = bplib_mpool_bblock_primary_cast(pblk);
@@ -318,7 +318,7 @@ static bplib_mpool_block_t *bplib_file_offload_read_blocks(int fd, bplib_file_of
             bplib_file_offload_read_block_content(fd, rec, &pri_block->data, sizeof(pri_block->data));
             while (rec->num_blocks > 0)
             {
-                cblk = bplib_mpool_bblock_canonical_alloc(pool);
+                cblk = bplib_mpool_bblock_canonical_alloc(pool, 0, NULL);
                 if (cblk == NULL)
                 {
                     break;

--- a/v7/src/v7_codec.c
+++ b/v7/src/v7_codec.c
@@ -1833,7 +1833,7 @@ size_t v7_copy_full_bundle_in(bplib_mpool_bblock_primary_t *cpb, const void *buf
             /* Anything beyond first block is always a canonical block */
 
             /* Allocate Blocks */
-            cblk = bplib_mpool_bblock_canonical_alloc(ppool);
+            cblk = bplib_mpool_bblock_canonical_alloc(ppool, 0, NULL);
             ccb  = bplib_mpool_bblock_canonical_cast(cblk);
             if (ccb == NULL)
             {


### PR DESCRIPTION
Notably this allows use of a supplemental constructor/destructor on bundle blocks, permitting extra action to be taken when a
block is created or recycled.

Fixes #110