### PR TITLE
Fix #113, better handling of dependent library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
 
 
   # link with the requisite dependencies (this is mainly for POSIX, if using that adapter)
-  target_link_libraries(bplib ${TINYCBOR_LIBRARIES} ${BPLIB_LINK_LIBRARIES})
+  target_link_libraries(bplib ${TINYCBOR_LDFLAGS} ${BPLIB_LINK_LIBRARIES})
 
   # Install and also export this library, so it can be found via
   # "find_package()" from some other CMake build

--- a/v7/CMakeLists.txt
+++ b/v7/CMakeLists.txt
@@ -10,7 +10,7 @@
 # The BPv7 codec code currently uses the TinyCBOR external library
 # Use pkg-config to locate tinycbor dependency (for now)
 find_package(PkgConfig)
-pkg_search_module(TINYCBOR tinycbor)
+pkg_search_module(TINYCBOR tinycbor REQUIRED)
 message(STATUS "Found tinycbor version ${TINYCBOR_VERSION}")
 
 add_library(bplib_v7 OBJECT
@@ -35,7 +35,7 @@ target_include_directories(bplib_v7 PUBLIC
      ${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
 
-target_link_libraries(bplib_v7 ${TINYCBOR_LIBRARIES})
+target_link_libraries(bplib_v7 ${TINYCBOR_LDFLAGS})
 
 # compile this submodule as c99
 target_compile_features(bplib_v7 PRIVATE c_std_99)


### PR DESCRIPTION
For the tinycbor dependency, makes two simple updates:
- mark it as "REQUIRED" so its more obvious if it is not found
- use "LDFLAGS" rather than "LIBRARIES" in case it is in a non-system path

Fixes #113