### PR TITLE
Fix #117, order of ops on custody ACK

### DIFF
--- a/cache/src/v7_cache_internal.h
+++ b/cache/src/v7_cache_internal.h
@@ -147,7 +147,8 @@ typedef struct bplib_cache_custodian_info
     bool                 match_dacs;
     bp_ipn_addr_t        flow_id;
     bp_ipn_addr_t        custodian_id;
-    bplib_mpool_block_t *cblk;
+    bplib_mpool_block_t *this_cblk;
+    bplib_mpool_block_t *prev_cblk;
     bp_val_t             eid_hash;
     bp_sequencenumber_t  sequence_num;
     bp_ipn_t             final_dest_node;

--- a/mpool/src/v7_mpool_bblocks.c
+++ b/mpool/src/v7_mpool_bblocks.c
@@ -295,7 +295,6 @@ size_t bplib_mpool_bblock_cbor_export(bplib_mpool_block_t *list, void *out_ptr, 
 void bplib_mpool_bblock_primary_append(bplib_mpool_bblock_primary_t *cpb, bplib_mpool_block_t *blk)
 {
     bplib_mpool_bblock_canonical_t *ccb;
-    bp_blocktype_t                  block_type;
 
     /* this should only be invoked w/canonical blocks.  Anything else is a bug. */
     ccb = bplib_mpool_bblock_canonical_cast(blk);
@@ -307,12 +306,9 @@ void bplib_mpool_bblock_primary_append(bplib_mpool_bblock_primary_t *cpb, bplib_
      * but other blocks may appear in any order.  It is not clear if there is any reason
      * to be more specific about block order.
      *
-     * For now, if the block being inserted is payload, put it last, otherwise put it first.
+     * For now, if the block being inserted has block num 1, put it last, otherwise put it first.
      */
-    block_type = bplib_mpool_bblock_canonical_get_logical(ccb)->canonical_block.blockType;
-
-    if (block_type == bp_blocktype_payloadBlock ||
-        (block_type >= bp_blocktype_SPECIAL_PAYLOADS_START && block_type < bp_blocktype_SPECIAL_PAYLOADS_MAX))
+    if (bplib_mpool_bblock_canonical_get_logical(ccb)->canonical_block.blockNum == 1)
     {
         /* this puts it last */
         bplib_mpool_insert_before(&cpb->cblock_list, blk);

--- a/v7/inc/v7_types.h
+++ b/v7/inc/v7_types.h
@@ -61,20 +61,16 @@ typedef enum bp_blocktype
     bp_blocktype_MAX_NORMAL                  = 12,
 
     /*
-     * These are internal block types - they are encoded into the bundle as type 1 (payload)
-     * because of the constraint in RFC9171 that says all bundles must have one and only one
-     * payload block, but in reality there are different flavors of payload blocks depending
-     * on what type of bundle it is.
-     *
-     * Therefore, the logical data for these canonical blocks will have the real type, which
-     * is deduced from the other bundle block contents, but CBOR-encoded content will have a
-     * value of 1.
+     * These are internal block types - they exist only locally in this implementation
+     * and the CBOR/RFC9171-compliant encoding uses a different type (possibly as 1 for
+     * the payload block, or it may not appear in the RFC-compliant bundle at all).
      */
-    bp_blocktype_SPECIAL_PAYLOADS_START    = 100,
-    bp_blocktype_adminRecordPayloadBlock   = bp_blocktype_SPECIAL_PAYLOADS_START,
+    bp_blocktype_SPECIAL_BLOCKS_START      = 100,
+    bp_blocktype_adminRecordPayloadBlock   = bp_blocktype_SPECIAL_BLOCKS_START,
     bp_blocktype_ciphertextPayloadBlock    = 101,
     bp_blocktype_custodyAcceptPayloadBlock = 102,
-    bp_blocktype_SPECIAL_PAYLOADS_MAX
+    bp_blocktype_previousCustodianBlock    = 103,
+    bp_blocktype_SPECIAL_BLOCKS_MAX
 } bp_blocktype_t;
 
 typedef enum bp_adminrectype


### PR DESCRIPTION
Correction for order of operations on custody signaling.  Wait until successful storage to generate the custody ACK.

Fixes #117