### PR TITLE
Fix #123, no custody processing for ram-only storage

### DIFF
--- a/app/bptest.c
+++ b/app/bptest.c
@@ -439,47 +439,6 @@ int bplib2_bundle_test(void)
         return lib_status;
     }
 
-    /* now wait for the DACS signal, which comes out after a delay */
-    printf("@%lu: waiting for ACK Bundle...\n", (unsigned long)bplib_os_get_dtntime_ms());
-
-    bundle_sz  = sizeof(bundle_buffer);
-    lib_status = bplib_cla_egress(s2_rtbl, s2_intf_cla, bundle_buffer, &bundle_sz, 5000000);
-    if (lib_status != 0)
-    {
-        fprintf(stderr, "Failed bplib_cla_egress() for DACS  code=%d... exiting\n", lib_status);
-        return lib_status;
-    }
-
-    /* wait for any pending data flows to complete */
-    bplib_route_maintenance_complete_wait(s2_rtbl);
-
-    printf("@%lu: ACK Bundle content:\n", (unsigned long)bplib_os_get_dtntime_ms());
-    display(stdout, bundle_buffer, 0, bundle_sz);
-
-    fd = open("ack.cbor", O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    if (fd < 0)
-    {
-        perror("open()");
-        return -1;
-    }
-
-    if (write(fd, bundle_buffer, bundle_sz) != bundle_sz)
-    {
-        perror("write");
-    }
-    close(fd);
-
-    printf("@%lu: sending ACK to originator...\n", (unsigned long)bplib_os_get_dtntime_ms());
-
-    lib_status = bplib_cla_ingress(s1_rtbl, s1_intf_cla, bundle_buffer, bundle_sz, BP_CHECK);
-    if (lib_status != 0)
-    {
-        fprintf(stderr, "Failed bplib_cla_ingress() code=%d... exiting\n", lib_status);
-        return lib_status;
-    }
-
-    bplib_route_maintenance_complete_wait(s1_rtbl);
-
     /* let some additional maintenance cycles run */
     printf("@%lu: shutting down...\n", (unsigned long)bplib_os_get_dtntime_ms());
     sleep(2);

--- a/cache/src/v7_cache_fsm.c
+++ b/cache/src/v7_cache_fsm.c
@@ -232,9 +232,16 @@ static void bplib_cache_fsm_reschedule(bplib_cache_state_t *state, bplib_cache_e
     }
 }
 
+static bplib_cache_entry_state_t bplib_cache_fsm_state_noop_eval(bplib_cache_entry_t *store_entry)
+{
+    /* entries which reach this state will be discarded immediately */
+    return bplib_cache_entry_state_undefined;
+}
+
 static bplib_cache_entry_state_t bplib_cache_fsm_get_next_state(bplib_cache_entry_t *entry)
 {
     static const bplib_cache_fsm_state_eval_func_t STATE_EVAL_TABLE[bplib_cache_entry_state_max] = {
+        [bplib_cache_entry_state_undefined]     = bplib_cache_fsm_state_noop_eval,
         [bplib_cache_entry_state_idle]          = bplib_cache_fsm_state_idle_eval,
         [bplib_cache_entry_state_queue]         = bplib_cache_fsm_state_queue_eval,
         [bplib_cache_entry_state_delete]        = bplib_cache_fsm_state_delete_eval,
@@ -359,6 +366,7 @@ void bplib_cache_fsm_execute(bplib_mpool_block_t *sblk)
             bplib_cache_fsm_transition_state(store_entry, next_state);
         }
 
+        /* entries get set into the "undefined" state once the FSM determines it is no longer useful at all */
         if (next_state == bplib_cache_entry_state_undefined)
         {
             bplib_cache_fsm_debug_report_discard(store_entry);


### PR DESCRIPTION
Do not claim custody of a bundle (no custody block update, no ACK) unless offload service is configured.  For RAM-only, the bundle will be passed through as-is.

Fixes #123