### PR TITLE
Fix #122, bundle ordering in bpcat

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(bptest PRIVATE ${BPAPP_COMPILE_OPTIONS})
 target_compile_options(rbtest PRIVATE ${BPAPP_COMPILE_OPTIONS})
 
 # Low level test apps may include "private" headers, whereas higher level tests should not
+target_include_directories(bpcat PRIVATE ${BPLIB_PRIVATE_INCLUDE_DIRS})
 target_include_directories(bptest PRIVATE ${BPLIB_PRIVATE_INCLUDE_DIRS})
 target_include_directories(rbtest PRIVATE ${BPLIB_PRIVATE_INCLUDE_DIRS})
 

--- a/mpool/src/v7_mpool.c
+++ b/mpool/src/v7_mpool.c
@@ -1199,9 +1199,9 @@ bplib_mpool_t *bplib_mpool_create(void *pool_mem, size_t pool_size)
      */
     admin->bblock_alloc_threshold   = (admin->num_bufs_total * 30) / 100;
     admin->internal_alloc_threshold = (admin->num_bufs_total * 10) / 100;
-    printf("%s(): created pool of size %zu, with %u chunks, bblock threshold = %u, internal threshold = %u\n", __func__,
-           pool_size, (unsigned int)admin->num_bufs_total, (unsigned int)admin->bblock_alloc_threshold,
-           (unsigned int)admin->internal_alloc_threshold);
+    fprintf(stderr, "%s(): created pool of size %zu, with %u chunks, bblock threshold = %u, internal threshold = %u\n",
+            __func__, pool_size, (unsigned int)admin->num_bufs_total, (unsigned int)admin->bblock_alloc_threshold,
+            (unsigned int)admin->internal_alloc_threshold);
 
     return pool;
 }


### PR DESCRIPTION
Adds a layer between bplib and stdout to reorder the data segments such that the stream will be reconstituted at the receiver correctly.  Window size is currently fixed.

Fixes #122