### PR TITLE
Fix #134, add target properties for submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ option(BPLIB_BUILD_TEST_TOOLS "Whether or not to build the test programs as part
 set(BPLIB_VERSION_STRING "3.0.99") # development
 
 set(BPLIB_COMMON_COMPILE_OPTIONS)
+set(BPLIB_COMMON_PROPERTIES)
+
+# If doing a CFS build, then build position independent code (-fPIC) for all objects
+if(IS_CFS_ARCH_BUILD OR BUILD_SHARED_LIBS)
+  list(APPEND BPLIB_COMMON_PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+endif()
+
 
 # If using a GNU-style compiler then enable full warnings here.
 # May want to add equivalent for other compiler flavors too
@@ -128,7 +135,10 @@ if (IS_CFS_ARCH_BUILD)
   # Create the app module using the CFE/OSAL adapter layer
   # Note this ignores the setting of BPLIB_INCLUDE_POSIX, as OSAL provides this service
   # The CFE build system determines whether to create a shared or static object inside this routine
-  add_cfe_app(bplib ${BPLIB_SRC} os/cfe.c)
+  # TEMPORARY - for now this will also use POSIX until OSAL has the needed features.
+  add_cfe_app(bplib ${BPLIB_SRC} os/posix.c)
+
+  target_link_libraries(bplib ${TINYCBOR_LDFLAGS})
 
 else()
 

--- a/cache/CMakeLists.txt
+++ b/cache/CMakeLists.txt
@@ -29,3 +29,4 @@ target_include_directories(bplib_cache PUBLIC
 # Use the same basic compiler flags as bplib
 target_compile_features(bplib_cache PRIVATE c_std_99)
 target_compile_options(bplib_cache PRIVATE ${BPLIB_COMMON_COMPILE_OPTIONS})
+set_target_properties(bplib_cache PROPERTIES ${BPLIB_COMMON_PROPERTIES})

--- a/mpool/CMakeLists.txt
+++ b/mpool/CMakeLists.txt
@@ -30,3 +30,4 @@ target_include_directories(bplib_mpool PUBLIC
 # Use the same basic compiler flags as bplib
 target_compile_features(bplib_mpool PRIVATE c_std_99)
 target_compile_options(bplib_mpool PRIVATE ${BPLIB_COMMON_COMPILE_OPTIONS})
+set_target_properties(bplib_mpool PROPERTIES ${BPLIB_COMMON_PROPERTIES})

--- a/v7/CMakeLists.txt
+++ b/v7/CMakeLists.txt
@@ -42,3 +42,4 @@ target_compile_features(bplib_v7 PRIVATE c_std_99)
 
 # Use the same basic compiler flags as bplib
 target_compile_options(bplib_v7 PRIVATE ${BPLIB_COMMON_COMPILE_OPTIONS})
+set_target_properties(bplib_v7 PROPERTIES ${BPLIB_COMMON_PROPERTIES})


### PR DESCRIPTION
This allows the "position independent code" property to be set when building for CFE.  This also includes a temporary change to use the posix os layer for cfe, until OSAL can get updated with the required sync primitives.

Fixes #134 