### PR TITLE
Fix #139, log to stderr instead of stdout

### DIFF
--- a/app/bpcat.c
+++ b/app/bpcat.c
@@ -809,6 +809,8 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    bplib_os_enable_log_flags(0xFFFFFFFF);
+
     /* Process Command Line */
     parse_options(argc, argv);
     parse_address(local_address_string, &local_addr);

--- a/inc/bplib_os.h
+++ b/inc/bplib_os.h
@@ -63,6 +63,7 @@
  ******************************************************************************/
 
 void bplib_os_init(void);
+void bplib_os_enable_log_flags(uint32_t enable_mask);
 int  bplib_os_log(const char *file, unsigned int line, uint32_t *flags, uint32_t event, const char *fmt, ...)
     VARG_CHECK(printf, 5, 6);
 int      bplib_os_systime(unsigned long *sysnow); /* seconds */

--- a/os/posix.c
+++ b/os/posix.c
@@ -162,7 +162,7 @@ int bplib_os_log(const char *file, unsigned int line, uint32_t *flags, uint32_t 
             }
 
             /* Display Log Message */
-            printf("%s", log_message);
+            fputs(log_message, stderr);
         }
     }
 


### PR DESCRIPTION
Enable all debug messages for bpcat, and write to stderr instead of stdout.

Fixes #139