### PR TITLE
Fix #127, process cache pending_list as a triggered job

### DIFF
--- a/cache/src/v7_cache_internal.h
+++ b/cache/src/v7_cache_internal.h
@@ -66,6 +66,8 @@ typedef struct bplib_cache_state
 {
     bp_ipn_addr_t self_addr;
 
+    bplib_mpool_job_t       pending_job;
+
     /*
      * pending_list holds bundle refs that are currently actionable in some way,
      * such as one of its timers getting reached, or the state flags changed.

--- a/mpool/src/v7_mpool_job.c
+++ b/mpool/src/v7_mpool_job.c
@@ -101,6 +101,7 @@ void bplib_mpool_job_mark_active(bplib_mpool_job_t *job)
 
     lock = bplib_mpool_lock_resource(pool);
     bplib_mpool_job_mark_active_internal(&admin->active_list, job);
+    bplib_mpool_lock_broadcast_signal(lock);
     bplib_mpool_lock_release(lock);
 }
 


### PR DESCRIPTION
This was previously handled during polling cycles, so bundles that are pending have to wait until the next cycle.  Making it scheduled improves throughput/response time.

Fixes #127
