### PR TITLE
Fix #128, input depth limit

### DIFF
--- a/cache/src/v7_cache.c
+++ b/cache/src/v7_cache.c
@@ -190,15 +190,20 @@ int bplib_cache_do_intf_statechange(bplib_cache_state_t *state, bool is_up)
     bplib_mpool_flow_t *self_flow;
 
     self_flow = bplib_cache_get_flow(state);
-    if (is_up)
-    {
-        self_flow->ingress.current_depth_limit = BP_MPOOL_MAX_SUBQ_DEPTH;
-        self_flow->egress.current_depth_limit  = BP_MPOOL_MAX_SUBQ_DEPTH;
-    }
-    else
+    if (!is_up)
     {
         self_flow->ingress.current_depth_limit = 0;
         self_flow->egress.current_depth_limit  = 0;
+    }
+    else if ((self_flow->current_state_flags & BPLIB_MPOOL_FLOW_FLAGS_ENDPOINT) != 0)
+    {
+        self_flow->ingress.current_depth_limit = BP_MPOOL_SHORT_SUBQ_DEPTH;
+        self_flow->egress.current_depth_limit  = BP_MPOOL_SHORT_SUBQ_DEPTH;
+    }
+    else
+    {
+        self_flow->ingress.current_depth_limit = BP_MPOOL_MAX_SUBQ_DEPTH;
+        self_flow->egress.current_depth_limit  = BP_MPOOL_MAX_SUBQ_DEPTH;
     }
     return BP_SUCCESS;
 }

--- a/lib/v7_dataservice_api.c
+++ b/lib/v7_dataservice_api.c
@@ -539,7 +539,14 @@ int bplib_dataservice_event_impl(void *arg, bplib_mpool_block_t *intf_block)
     if (event->event_type == bplib_mpool_flow_event_up)
     {
         /* Allows bundles to be pushed to flow queues */
-        bplib_mpool_flow_enable(&flow->ingress, BP_MPOOL_MAX_SUBQ_DEPTH);
+        if (flow->current_state_flags & BPLIB_MPOOL_FLOW_FLAGS_ENDPOINT)
+        {
+            bplib_mpool_flow_enable(&flow->ingress, BP_MPOOL_SHORT_SUBQ_DEPTH);
+        }
+        else
+        {
+            bplib_mpool_flow_enable(&flow->ingress, BP_MPOOL_MAX_SUBQ_DEPTH);
+        }
         bplib_mpool_flow_enable(&flow->egress, BP_MPOOL_MAX_SUBQ_DEPTH);
     }
     else if (event->event_type == bplib_mpool_flow_event_down)
@@ -848,7 +855,7 @@ int bplib_connect_socket(bp_socket_t *desc, const bp_ipn_addr_t *destination_ipn
 
     sock->params.remote_ipn = *destination_ipn;
 
-    bplib_route_intf_set_flags(sock->parent_rtbl, sock->socket_intf_id,
+    bplib_route_intf_set_flags(sock->parent_rtbl, sock->socket_intf_id,  BPLIB_MPOOL_FLOW_FLAGS_ENDPOINT |
                                BPLIB_INTF_STATE_ADMIN_UP | BPLIB_INTF_STATE_OPER_UP);
 
     return 0;

--- a/mpool/inc/v7_mpool_flows.h
+++ b/mpool/inc/v7_mpool_flows.h
@@ -29,6 +29,7 @@
 #define BPLIB_MPOOL_FLOW_FLAGS_ADMIN_UP 0x01
 #define BPLIB_MPOOL_FLOW_FLAGS_OPER_UP  0x02
 #define BPLIB_MPOOL_FLOW_FLAGS_STORAGE  0x04
+#define BPLIB_MPOOL_FLOW_FLAGS_ENDPOINT 0x08
 #define BPLIB_MPOOL_FLOW_FLAGS_POLL     0x10
 
 /**
@@ -42,7 +43,8 @@
  * there will still never be any ambiguity or chance of overrunning the counters used
  * to track queue depth (which are currently 32 bit values).
  */
-#define BP_MPOOL_MAX_SUBQ_DEPTH 0x10000000
+#define BP_MPOOL_MAX_SUBQ_DEPTH   0x10000000
+#define BP_MPOOL_SHORT_SUBQ_DEPTH 0x10
 
 /*
  * Enumeration that defines the various possible routing table events.  This enum


### PR DESCRIPTION
Reduce the depth limit of the ingress queue, so bundles do not get bunched up at the entry point.

Fixes #128