### PR TITLE
Fix #138, add counters to state machine

### DIFF
--- a/app/bpcat.c
+++ b/app/bpcat.c
@@ -45,6 +45,7 @@
 #include "bplib_store_ram.h"
 
 #include "v7_rbtree.h"
+#include "v7_cache.h"
 
 /* BPCAT_MAX_WAIT_MSEC controls the amount of time waiting for reading/writing to queues/files by
  * the data mover threads.  This is time limited so the "app_running" flag is checked periodically.
@@ -798,6 +799,8 @@ int main(int argc, char *argv[])
     bp_ipn_addr_t     local_addr;
     bp_ipn_addr_t     remote_addr;
     bp_ipn_addr_t     storage_addr;
+    uint64_t          stats_time;
+    uint64_t          curr_time;
 
     app_running = 1;
     signal(SIGINT, app_quick_exit);
@@ -843,6 +846,7 @@ int main(int argc, char *argv[])
     }
 
     /* Run management Loop */
+    stats_time = bplib_os_get_dtntime_ms() + 10000;
     while (app_running)
     {
         bplib_route_maintenance_request_wait(rtbl);
@@ -852,6 +856,13 @@ int main(int argc, char *argv[])
         /* do maintenance regardless of what the "request" returned, as that
          * currently only reflects actual requests, not time-based poll actions */
         bplib_route_periodic_maintenance(rtbl);
+
+        curr_time = bplib_os_get_dtntime_ms();
+        if (curr_time >= stats_time)
+        {
+            bplib_cache_debug_scan(rtbl, storage_intf_id);
+            stats_time += 10000;
+        }
     }
 
     /* Join Threads */

--- a/cache/src/v7_cache.c
+++ b/cache/src/v7_cache.c
@@ -612,6 +612,19 @@ int bplib_cache_stop(bplib_routetbl_t *tbl, bp_handle_t module_intf_id)
     return result;
 }
 
+#define bplib_cache_debug_fsm_state_print(s, n) bplib_cache_debug_fsm_state_print_impl(s, n, "[" #n "]")
+void bplib_cache_debug_fsm_state_print_impl(bplib_cache_state_t *state, bplib_cache_entry_state_t n, const char *fsmname)
+{
+    uint32_t entercount;
+    uint32_t exitcount;
+
+    entercount = state->fsm_state_enter_count[n];
+    exitcount = state->fsm_state_exit_count[n];
+
+    fprintf(stderr, " STATE STATS: %45s enter=%lu exit=%lu current=%lu\n", fsmname,
+        (unsigned long)entercount, (unsigned long)exitcount, (unsigned long)(entercount - exitcount));
+}
+
 void bplib_cache_debug_scan(bplib_routetbl_t *tbl, bp_handle_t intf_id)
 {
     bplib_mpool_ref_t    intf_block_ref;
@@ -631,10 +644,14 @@ void bplib_cache_debug_scan(bplib_routetbl_t *tbl, bp_handle_t intf_id)
         return;
     }
 
-    printf("DEBUG: %s() intf_id=%d\n", __func__, bp_handle_printable(intf_id));
+    fprintf(stderr, "DEBUG: %s() intf_id=%d\n", __func__, bp_handle_printable(intf_id));
 
-    bplib_mpool_debug_print_list_stats(&state->pending_list, "pending_list");
-    bplib_mpool_debug_print_list_stats(&state->idle_list, "idle_list");
+    bplib_cache_debug_fsm_state_print(state, bplib_cache_entry_state_undefined);
+    bplib_cache_debug_fsm_state_print(state, bplib_cache_entry_state_idle);
+    bplib_cache_debug_fsm_state_print(state, bplib_cache_entry_state_queue);
+    bplib_cache_debug_fsm_state_print(state, bplib_cache_entry_state_delete);
+    bplib_cache_debug_fsm_state_print(state, bplib_cache_entry_state_generate_dacs);
+    fprintf(stderr, " DISCARDED BUNDLES: %lu\n\n", (unsigned long)state->discard_count);
 
     bplib_route_release_intf_controlblock(tbl, intf_block_ref);
 }

--- a/cache/src/v7_cache_custody.c
+++ b/cache/src/v7_cache_custody.c
@@ -244,6 +244,7 @@ void bplib_cache_custody_open_dacs(bplib_cache_state_t *state, bplib_cache_custo
         pri_block->data.delivery.committed_storage_id = (bp_sid_t)sblk;
 
         store_entry->state = bplib_cache_entry_state_generate_dacs;
+        ++state->fsm_state_enter_count[store_entry->state];
 
         /* the "action_time" reflects when this bundle will be finalized and sent, until
          * then it is open for appending with additional sequence numbers. */
@@ -591,6 +592,8 @@ void bplib_cache_custody_store_bundle(bplib_cache_state_t *state, bplib_mpool_bl
         {
             custody_info.store_entry->state = bplib_cache_entry_state_idle;
         }
+
+        ++state->fsm_state_enter_count[custody_info.store_entry->state];
 
         /* This puts it into the right spot for future holding */
         bplib_cache_fsm_execute(sblk);

--- a/cache/src/v7_cache_fsm.c
+++ b/cache/src/v7_cache_fsm.c
@@ -363,12 +363,15 @@ void bplib_cache_fsm_execute(bplib_mpool_block_t *sblk)
         next_state = bplib_cache_fsm_get_next_state(store_entry);
         if (next_state != store_entry->state)
         {
+            ++state->fsm_state_exit_count[store_entry->state];
             bplib_cache_fsm_transition_state(store_entry, next_state);
+            ++state->fsm_state_enter_count[next_state];
         }
 
         /* entries get set into the "undefined" state once the FSM determines it is no longer useful at all */
         if (next_state == bplib_cache_entry_state_undefined)
         {
+            ++state->discard_count;
             bplib_cache_fsm_debug_report_discard(store_entry);
             bplib_mpool_recycle_block(sblk);
         }

--- a/cache/src/v7_cache_internal.h
+++ b/cache/src/v7_cache_internal.h
@@ -62,6 +62,16 @@
 
 #define BP_CACHE_TIME_INFINITE BP_DTNTIME_INFINITE
 
+typedef enum bplib_cache_entry_state
+{
+    bplib_cache_entry_state_undefined,
+    bplib_cache_entry_state_idle,
+    bplib_cache_entry_state_queue,
+    bplib_cache_entry_state_delete,
+    bplib_cache_entry_state_generate_dacs,
+    bplib_cache_entry_state_max
+} bplib_cache_entry_state_t;
+
 typedef struct bplib_cache_state
 {
     bp_ipn_addr_t self_addr;
@@ -96,17 +106,11 @@ typedef struct bplib_cache_state
 
     uint32_t generated_dacs_seq;
 
-} bplib_cache_state_t;
+    uint32_t fsm_state_enter_count[bplib_cache_entry_state_max];
+    uint32_t fsm_state_exit_count[bplib_cache_entry_state_max];
+    uint32_t discard_count;
 
-typedef enum bplib_cache_entry_state
-{
-    bplib_cache_entry_state_undefined,
-    bplib_cache_entry_state_idle,
-    bplib_cache_entry_state_queue,
-    bplib_cache_entry_state_delete,
-    bplib_cache_entry_state_generate_dacs,
-    bplib_cache_entry_state_max
-} bplib_cache_entry_state_t;
+} bplib_cache_state_t;
 
 typedef struct bplib_cache_dacs_pending
 {


### PR DESCRIPTION
Add entry/exit counters for each state of the storage cache bundle handling state machine.  This indicates bundles that are idle, queued, deleted, and eventually discarded.

Update bpcat to display these counters every 10 seconds.

Fixes #138