### PR TITLE
Fix #136, do not set link libs on object lib

### DIFF
--- a/v7/CMakeLists.txt
+++ b/v7/CMakeLists.txt
@@ -35,8 +35,6 @@ target_include_directories(bplib_v7 PUBLIC
      ${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
 
-target_link_libraries(bplib_v7 ${TINYCBOR_LDFLAGS})
-
 # compile this submodule as c99
 target_compile_features(bplib_v7 PRIVATE c_std_99)
 


### PR DESCRIPTION
The cmake script was incorrectly setting the target_link_libraries on the object library.  Although this code is what requires the
library, only the compile flags are needed here.  The link libs are required at the parent library link, and they are already
there (so this is redundant). 

New CMake versions appear to have simply ignored this line, but old CMake versions produce an error.

Fixes #136