### PR TITLE
Fix #137, add block allocator priority

### DIFF
--- a/cache/src/v7_cache_custody.c
+++ b/cache/src/v7_cache_custody.c
@@ -153,7 +153,7 @@ bplib_mpool_ref_t bplib_cache_custody_create_dacs(bplib_cache_state_t           
 
     do
     {
-        pblk      = bplib_mpool_bblock_primary_alloc(ppool, 0, NULL);
+        pblk      = bplib_mpool_bblock_primary_alloc(ppool, 0, NULL, BPLIB_MPOOL_ALLOC_PRI_MED, 0);
         pri_block = bplib_mpool_bblock_primary_cast(pblk);
         if (pri_block == NULL)
         {

--- a/lib/v7_cla_api.c
+++ b/lib/v7_cla_api.c
@@ -106,8 +106,14 @@ int bplib_generic_bundle_ingress(bplib_mpool_ref_t flow_ref, const void *content
     }
     else
     {
+        /*
+         * Note - it is not yet known whether this might be a regular data bundle or a DACS.  If under memory pressure, then
+         * it is critical to allow DACS in, because that should free more blocks, relieving the pressure.  Therefore,
+         * the block allocation is done with a high-ish priority here, but if it ends up to be a regular bundle and there
+         * isn't a lot of memory available, this might get discarded later.
+         */
         pblk = bplib_mpool_bblock_primary_alloc(
-            bplib_mpool_get_parent_pool_from_link(bplib_mpool_dereference(flow_ref)), 0, NULL);
+            bplib_mpool_get_parent_pool_from_link(bplib_mpool_dereference(flow_ref)), 0, NULL, BPLIB_MPOOL_ALLOC_PRI_MHI, 0);
         if (pblk != NULL)
         {
             imported_sz = v7_copy_full_bundle_in(bplib_mpool_bblock_primary_cast(pblk), content, size);

--- a/lib/v7_dataservice_api.c
+++ b/lib/v7_dataservice_api.c
@@ -77,28 +77,20 @@ struct bplib_socket_info
  LOCAL FUNCTIONS
  ******************************************************************************/
 
-bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_inf, const void *content, size_t size)
+int bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_inf, bplib_mpool_block_t *pblk, const void *content, size_t size)
 {
-    bplib_mpool_t    *pool;
-    bplib_mpool_ref_t refptr;
-
-    bplib_mpool_block_t *pblk;
     bplib_mpool_block_t *cblk;
-
     bplib_mpool_bblock_primary_t   *pri_block;
     bp_primary_block_t             *pri;
     bplib_mpool_bblock_canonical_t *ccb_pay;
     bp_canonical_block_buffer_t    *pay;
+    int result;
 
-    /* Allocate Blocks */
-    pool   = bplib_route_get_mpool(sock_inf->parent_rtbl);
     cblk   = NULL;
-    pblk   = NULL;
-    refptr = NULL;
+    result = BP_ERROR;
 
     do
     {
-        pblk      = bplib_mpool_bblock_primary_alloc(pool, 0, NULL);
         pri_block = bplib_mpool_bblock_primary_cast(pblk);
         if (pri_block == NULL)
         {
@@ -136,7 +128,7 @@ bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_
         }
 
         /* Update Payload Block */
-        cblk    = bplib_mpool_bblock_canonical_alloc(pool, 0, NULL);
+        cblk    = bplib_mpool_bblock_canonical_alloc(bplib_route_get_mpool(sock_inf->parent_rtbl), 0, NULL);
         ccb_pay = bplib_mpool_bblock_canonical_cast(cblk);
         if (ccb_pay == NULL)
         {
@@ -159,17 +151,7 @@ bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_
 
         bplib_mpool_bblock_primary_append(pri_block, cblk);
         cblk = NULL; /* do not need now that it is stored */
-
-        /* Final step is to convert to a dynamically-managed ref for returning to caller */
-        refptr = bplib_mpool_ref_create(pblk);
-        if (refptr == NULL)
-        {
-            /* not expected... */
-            bplog(NULL, BP_FLAG_DIAGNOSTIC, "Cannot convert payload to ref\n");
-            break;
-        }
-
-        pblk = NULL; /* do not use original anymore */
+        result = BP_SUCCESS;
     }
     while (false);
 
@@ -179,12 +161,7 @@ bplib_mpool_ref_t bplib_serviceflow_bundleize_payload(bplib_socket_info_t *sock_
         bplib_mpool_recycle_block(cblk);
     }
 
-    if (pblk != NULL)
-    {
-        bplib_mpool_recycle_block(pblk);
-    }
-
-    return refptr;
+    return result;
 }
 
 int bplib_serviceflow_unbundleize_payload(bplib_socket_info_t *sock_inf, bplib_mpool_ref_t refptr, void *content,
@@ -892,13 +869,16 @@ int bplib_send(bp_socket_t *desc, const void *payload, size_t size, uint32_t tim
     bplib_mpool_block_t          *rblk;
     bplib_mpool_flow_t           *flow;
     bplib_mpool_ref_t             refptr;
+    bplib_mpool_block_t *pblk;
     bplib_mpool_bblock_primary_t *pri_block;
     bplib_mpool_ref_t             sock_ref;
     bplib_socket_info_t          *sock;
     uint64_t                      ingress_time;
+    uint64_t                      ingress_limit;
 
     sock_ref     = (bplib_mpool_ref_t)desc;
     ingress_time = bplib_os_get_dtntime_ms();
+    ingress_limit = ingress_time + timeout;
 
     sock = bplib_mpool_generic_data_cast(bplib_mpool_dereference(sock_ref), BPLIB_BLOCKTYPE_SERVICE_SOCKET);
     if (sock == NULL)
@@ -914,12 +894,32 @@ int bplib_send(bp_socket_t *desc, const void *payload, size_t size, uint32_t tim
         return BP_ERROR;
     }
 
-    refptr = bplib_serviceflow_bundleize_payload(sock, payload, size);
-    if (refptr == NULL)
+    /* If no pri block is available, this should block and wait for one (up to ingress_limit) */
+    pblk = bplib_mpool_bblock_primary_alloc(bplib_route_get_mpool(sock->parent_rtbl), 0, NULL, BPLIB_MPOOL_ALLOC_PRI_LO, ingress_limit);
+    if (pblk == NULL)
+    {
+        bplog(NULL, BP_FLAG_DIAGNOSTIC, "%s(): unable to alloc pri block\n", __func__);
+        return BP_TIMEOUT;
+    }
+
+    status = bplib_serviceflow_bundleize_payload(sock, pblk, payload, size);
+    if (status != BP_SUCCESS)
     {
         bplog(NULL, BP_FLAG_DIAGNOSTIC, "%s(): cannot bundleize payload, out of memory?\n", __func__);
+        return status;
+    }
+
+    /* convert to a dynamically-managed ref for passing in queues */
+    refptr = bplib_mpool_ref_create(pblk);
+    if (refptr == NULL)
+    {
+        /* not expected... */
+        bplib_mpool_recycle_block(pblk);
+        bplog(NULL, BP_FLAG_DIAGNOSTIC, "Cannot convert payload to ref\n");
         return BP_ERROR;
     }
+    pblk = NULL;    /* only the ref should be used from here */
+
 
     rblk = bplib_mpool_ref_make_block(refptr, BPLIB_BLOCKTYPE_SERVICE_BLOCK, NULL);
     if (rblk != NULL)
@@ -931,7 +931,7 @@ int bplib_send(bp_socket_t *desc, const void *payload, size_t size, uint32_t tim
             pri_block->data.delivery.ingress_time    = ingress_time;
         }
 
-        if (bplib_mpool_flow_try_push(&flow->ingress, rblk, ingress_time + timeout))
+        if (bplib_mpool_flow_try_push(&flow->ingress, rblk, ingress_limit))
         {
             sock->ingress_byte_count += size;
             status = BP_SUCCESS;

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -26,6 +26,23 @@
 #include "bplib_api_types.h"
 
 /*
+ * Priority levels for pool buffers -
+ * The intent here is to give some preference to things which may decrease pool
+ * memory usage (such as receipt of a DACS, which might allow dozens of
+ * bundles to be deleted) over things that may increase pool memory usage
+ * (such as an app sending in new data bundles).
+ *
+ * This only comes into play once the pool is mostly used.  As long as memory
+ * use is low, everything gets allocated without issue.  Once memory becomes
+ * constrained, things need to start becoming more choosy as to who gets the buffer.
+ */
+#define BPLIB_MPOOL_ALLOC_PRI_LO  0
+#define BPLIB_MPOOL_ALLOC_PRI_MLO 63
+#define BPLIB_MPOOL_ALLOC_PRI_MED 127
+#define BPLIB_MPOOL_ALLOC_PRI_MHI 191
+#define BPLIB_MPOOL_ALLOC_PRI_HI  255
+
+/*
  * The basic types of blocks which are cacheable in the mpool
  */
 typedef struct bplib_mpool_bblock_primary   bplib_mpool_bblock_primary_t;

--- a/mpool/inc/v7_mpool_bblocks.h
+++ b/mpool/inc/v7_mpool_bblocks.h
@@ -199,7 +199,7 @@ void bplib_mpool_bblock_cbor_set_size(bplib_mpool_block_t *cb, size_t user_conte
  * @param pool
  * @return bplib_mpool_block_t*
  */
-bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg);
+bplib_mpool_block_t *bplib_mpool_bblock_primary_alloc(bplib_mpool_t *pool, uint32_t magic_number, void *init_arg, uint8_t priority, uint64_t timeout);
 
 /**
  * @brief Allocate a new canonical block

--- a/mpool/src/v7_mpool_flows.c
+++ b/mpool/src/v7_mpool_flows.c
@@ -458,7 +458,7 @@ bplib_mpool_block_t *bplib_mpool_flow_alloc(bplib_mpool_t *pool, uint32_t magic_
     bplib_mpool_lock_t          *lock;
 
     lock   = bplib_mpool_lock_resource(pool);
-    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number, init_arg);
+    result = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_flow, magic_number, init_arg, BPLIB_MPOOL_ALLOC_PRI_LO);
     bplib_mpool_lock_release(lock);
 
     return (bplib_mpool_block_t *)result;

--- a/mpool/src/v7_mpool_internal.h
+++ b/mpool/src/v7_mpool_internal.h
@@ -343,6 +343,6 @@ const bplib_mpool_block_content_t *bplib_mpool_get_block_content_const(const bpl
 bplib_mpool_block_content_t *bplib_mpool_block_dereference_content(bplib_mpool_block_t *cb);
 
 bplib_mpool_block_content_t *bplib_mpool_alloc_block_internal(bplib_mpool_t *pool, bplib_mpool_blocktype_t blocktype,
-                                                              uint32_t content_type_signature, void *init_arg);
+                                                              uint32_t content_type_signature, void *init_arg, uint8_t priority);
 
 #endif /* V7_MPOOL_INTERNAL_H */

--- a/mpool/src/v7_mpool_ref.c
+++ b/mpool/src/v7_mpool_ref.c
@@ -98,7 +98,7 @@ bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_ref_t refptr, uint32
     pool = bplib_mpool_get_parent_pool_from_link(&bblk->header.base_link);
 
     lock = bplib_mpool_lock_resource(pool);
-    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg);
+    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg, BPLIB_MPOOL_ALLOC_PRI_MHI);
     bplib_mpool_lock_release(lock);
 
     if (rblk == NULL)

--- a/store/file_offload.c
+++ b/store/file_offload.c
@@ -306,7 +306,7 @@ static bplib_mpool_block_t *bplib_file_offload_read_blocks(int fd, bplib_file_of
 
     cblk    = NULL;
     c_block = NULL;
-    pblk    = bplib_mpool_bblock_primary_alloc(pool, 0, NULL);
+    pblk    = bplib_mpool_bblock_primary_alloc(pool, 0, NULL, BPLIB_MPOOL_ALLOC_PRI_MLO, 0);
     if (pblk != NULL)
     {
         pri_block = bplib_mpool_bblock_primary_cast(pblk);


### PR DESCRIPTION
Introduce a priority/criticality input on the general block allocator, which determines success if under memory pressure (i.e. high percentage of pool is used up).  Once memory becomes constrained, lower priority allocations will start to fail before higher priority allocation.

This allows for a "cushion" of buffers to ensure that buffers for important things like custody signals are still able to be allocated once general purpose memory capacity is running out.

Fixes #137