### PR TITLE
Fix #153, configuration tuning for larger files

### DIFF
--- a/app/bpcat.c
+++ b/app/bpcat.c
@@ -54,8 +54,8 @@
 //#define BPCAT_MAX_WAIT_MSEC         1800000
 #define BPCAT_MAX_WAIT_MSEC 250
 
-#define BPCAT_DATA_MESSAGE_MAX_SIZE 2552
-#define BPCAT_BUNDLE_BUFFER_SIZE    (sizeof(bpcat_msg_content_t) + 512)
+#define BPCAT_BUNDLE_BUFFER_SIZE    16384
+#define BPCAT_DATA_MESSAGE_MAX_SIZE (BPCAT_BUNDLE_BUFFER_SIZE - 520)
 #define BPCAT_RECV_WINDOW_SZ        32
 
 /*************************************************************************

--- a/cache/src/v7_cache_internal.h
+++ b/cache/src/v7_cache_internal.h
@@ -58,7 +58,7 @@
 #define BP_CACHE_DACS_OPEN_TIME  10000    /* 10 sec */
 #define BP_CACHE_FAST_RETRY_TIME 3000     /* 3 sec */
 #define BP_CACHE_IDLE_RETRY_TIME 3600000  /* 1 hour */
-#define BP_CACHE_AGE_OUT_TIME    60000    /* 1 minute */
+#define BP_CACHE_AGE_OUT_TIME    5000     /* 5 seconds */
 
 #define BP_CACHE_TIME_INFINITE BP_DTNTIME_INFINITE
 
@@ -76,7 +76,7 @@ typedef struct bplib_cache_state
 {
     bp_ipn_addr_t self_addr;
 
-    bplib_mpool_job_t       pending_job;
+    bplib_mpool_job_t pending_job;
 
     /*
      * pending_list holds bundle refs that are currently actionable in some way,


### PR DESCRIPTION
Increase bpcat buffer to 16KiB for more efficient transfer.
Decrease age out time to 5sec to clean out old index entries.

Fixes #153