### PR TITLE
Fix #160, update block type code for custody signaling

### DIFF
--- a/v7/inc/v7_types.h
+++ b/v7/inc/v7_types.h
@@ -57,8 +57,10 @@ typedef enum bp_blocktype
     bp_blocktype_metadataExtensionBlock      = 8,
     bp_blocktype_extensionSecurityBlock      = 9,
     bp_blocktype_hopCount                    = 10,
-    bp_blocktype_custodyTrackingBlock        = 11,
-    bp_blocktype_MAX_NORMAL                  = 12,
+    bp_blocktype_bpsec_bib                   = 11,
+    bp_blocktype_bpsec_bcb                   = 12,
+    bp_blocktype_custodyTrackingBlock        = 13,
+    bp_blocktype_MAX_NORMAL                  = 14,
 
     /*
      * These are internal block types - they exist only locally in this implementation


### PR DESCRIPTION
Block type codes 11 and 12 are defined by RFC9172 (bpsec).
Update DACS to block type code 13 as to not conflict.

Fixes #160