### PR TITLE
Fix #167, provide config/query API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (IS_CFS_ARCH_BUILD)
   # Note this ignores the setting of BPLIB_INCLUDE_POSIX, as OSAL provides this service
   # The CFE build system determines whether to create a shared or static object inside this routine
   # TEMPORARY - for now this will also use POSIX until OSAL has the needed features.
-  add_cfe_app(bplib ${BPLIB_SRC} os/posix.c)
+  add_cfe_app(bplib ${BPLIB_SRC} os/heap.c os/posix.c)
 
   target_link_libraries(bplib ${TINYCBOR_LDFLAGS})
 
@@ -77,7 +77,7 @@ else()
   # This by will usually require a POSIX OS layer
   if (BPLIB_INCLUDE_POSIX)
 
-    list(APPEND BPLIB_SRC os/posix.c)
+    list(APPEND BPLIB_SRC os/heap.c os/posix.c)
     list(APPEND BPLIB_LINK_LIBRARIES rt pthread)
 
   endif()

--- a/inc/bplib.h
+++ b/inc/bplib.h
@@ -76,7 +76,6 @@ extern "C" {
 #define BP_COS_EXPEDITED 2
 #define BP_COS_EXTENDED  3
 
-
 /******************************************************************************
  TYPEDEFS
  ******************************************************************************/
@@ -264,6 +263,37 @@ int bplib_cla_ingress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, const void *b
  * @retval BP_SUCCESS if successful
  */
 int bplib_cla_egress(bplib_routetbl_t *rtbl, bp_handle_t intf_id, void *bundle, size_t *size, uint32_t timeout);
+
+/**
+ * @brief Get an operational value
+ *
+ * Reads the current value of a single bplib operational variable.  For interface variables (such as bundle/byte counts)
+ * the intf_id specifies the scope to read.  For global scope variables, the intf_id should be passed as
+ * BP_INVALID_HANDLE.
+ *
+ * @param rtbl Routing table instance
+ * @param intf_id the interface (scope) to read, or BP_INVALID_HANDLE for global scope
+ * @param var_id the specific variable value to read
+ * @param[out] value the value to set
+ *
+ * @retval BP_SUCCESS if successfully read
+ */
+int bplib_query_integer(bplib_routetbl_t *rtbl, bp_handle_t intf_id, bplib_variable_t var_id, bp_sval_t *value);
+
+/**
+ * @brief Set an operational value
+ *
+ * Writes the value of a single bplib operational variable.  For interface variables (such as bundle/byte counts) the
+ * intf_id specifies the scope to write.  For global scope variables, the intf_id should be passed as BP_INVALID_HANDLE.
+ *
+ * @param rtbl Routing table instance
+ * @param intf_id the interface (scope) to write, or BP_INVALID_HANDLE for global scope
+ * @param var_id the specific variable value to write
+ * @param value the value to set
+ *
+ * @retval BP_SUCCESS if successfully written
+ */
+int bplib_config_integer(bplib_routetbl_t *rtbl, bp_handle_t intf_id, bplib_variable_t var_id, bp_sval_t value);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/inc/bplib_api_types.h
+++ b/inc/bplib_api_types.h
@@ -43,16 +43,9 @@ extern "C" {
 #define BP_LOCAL_SCOPE static
 #endif
 
-#ifndef BP_VAL_TYPE
-#define BP_VAL_TYPE unsigned long
-#endif
-
-#ifndef BP_INDEX_TYPE
-#define BP_INDEX_TYPE uint16_t
-#endif
-
-typedef BP_VAL_TYPE   bp_val_t;
-typedef BP_INDEX_TYPE bp_index_t;
+typedef uintmax_t bp_val_t;
+typedef intmax_t  bp_sval_t;
+typedef uint16_t  bp_index_t;
 
 /* Encoded Value (bounds size of bundle field values) */
 #define BP_MAX_ENCODED_VALUE BP_GET_MAXVAL(bp_val_t)
@@ -209,6 +202,14 @@ typedef struct
     uint32_t acknowledged_bundles; /* freed by custody signal - process */
     uint32_t active_bundles;       /* number of slots in active table in use */
 } bp_stats_t;
+
+typedef enum
+{
+    bplib_variable_none,            /**< reserved value, keep first */
+    bplib_variable_mem_current_use, /**< replaces bplib_os_memused() for external API use */
+    bplib_variable_mem_high_use,    /**< replaces bplib_os_memhigh() for external API use */
+    bplib_variable_max              /**< reserved value, keep last */
+} bplib_variable_t;
 
 /**
  * Checks for validity of given handle

--- a/lib/src/v7_bplib.c
+++ b/lib/src/v7_bplib.c
@@ -260,3 +260,62 @@ int bplib_ipn2eid(char *eid, size_t len, bp_ipn_t node, bp_ipn_t service)
 
     return BP_SUCCESS;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_query_integer
+ *
+ * Public API function
+ * See description in header for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int bplib_query_integer(bplib_routetbl_t *rtbl, bp_handle_t intf_id, bplib_variable_t var_id, bp_sval_t *value)
+{
+    int retval;
+
+    retval = BP_ERROR;
+
+    switch (var_id)
+    {
+        case bplib_variable_mem_current_use:
+            *value = bplib_mpool_query_mem_current_use(bplib_route_get_mpool(rtbl));
+            retval = BP_SUCCESS;
+            break;
+
+        case bplib_variable_mem_high_use:
+            *value = bplib_mpool_query_mem_max_use(bplib_route_get_mpool(rtbl));
+            retval = BP_SUCCESS;
+            break;
+
+        default:
+            /* non-readable variable */
+            *value = 0;
+            break;
+    }
+
+    return retval;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: bplib_config_integer
+ *
+ * Public API function
+ * See description in header for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int bplib_config_integer(bplib_routetbl_t *rtbl, bp_handle_t intf_id, bplib_variable_t var_id, bp_sval_t value)
+{
+    int retval;
+
+    retval = BP_ERROR;
+
+    switch (var_id)
+    {
+        default:
+            /* non-writable variable */
+            break;
+    }
+
+    return retval;
+}

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -609,6 +609,22 @@ int bplib_mpool_register_blocktype(bplib_mpool_t *pool, uint32_t magic_number, c
  */
 bplib_mpool_t *bplib_mpool_create(void *pool_mem, size_t pool_size);
 
+/**
+ * @brief Obtain current usage of a memory pool
+ *
+ * @param pool Pool object
+ * @return memory currently in use
+ */
+size_t bplib_mpool_query_mem_current_use(bplib_mpool_t *pool);
+
+/**
+ * @brief Obtain maximum usage of a memory pool
+ *
+ * @param pool Pool object
+ * @return maximum memory used
+ */
+size_t bplib_mpool_query_mem_max_use(bplib_mpool_t *pool);
+
 /* DEBUG/TEST verification routines */
 
 void bplib_mpool_debug_scan(bplib_mpool_t *pool);

--- a/mpool/src/v7_mpool_internal.h
+++ b/mpool/src/v7_mpool_internal.h
@@ -108,6 +108,7 @@ typedef struct bplib_mpool_block_admin_content
     uint32_t num_bufs_total;
     uint32_t bblock_alloc_threshold;   /**< threshold at which new bundles will no longer be allocatable */
     uint32_t internal_alloc_threshold; /**< threshold at which internal blocks will no longer be allocatable */
+    uint32_t max_alloc_watermark;
 
     bplib_rbt_root_t          blocktype_registry; /**< registry of block signature values */
     bplib_mpool_api_content_t blocktype_basic;    /**< a fixed entity in the registry for type 0 */

--- a/os/cfe.c
+++ b/os/cfe.c
@@ -51,9 +51,6 @@
  FILE DATA
  ******************************************************************************/
 
-static size_t current_memory_allocated = 0;
-static size_t highest_memory_allocated = 0;
-
 static uint32_t flag_log_enable = BP_FLAG_NONCOMPLIANT | BP_FLAG_DROPPED | BP_FLAG_BUNDLE_TOO_LARGE |
                                   BP_FLAG_UNKNOWNREC | BP_FLAG_INVALID_CIPHER_SUITEID |
                                   BP_FLAG_INVALID_BIB_RESULT_TYPE | BP_FLAG_INVALID_BIB_TARGET_TYPE |
@@ -271,69 +268,3 @@ int bplib_os_strnlen(const char *str, int maxlen)
     return maxlen;
 }
 
-/*----------------------------------------------------------------------------
- * bplib_os_calloc
- *----------------------------------------------------------------------------*/
-void *bplib_os_calloc(size_t size)
-{
-    /* Allocate Memory Block */
-    size_t   block_size = size + sizeof(size_t);
-    uint8_t *mem_ptr    = (uint8_t *)calloc(block_size, 1);
-    if (mem_ptr)
-    {
-        /* Prepend Amount */
-        size_t *size_ptr = (size_t *)mem_ptr;
-        *size_ptr        = block_size;
-
-        /* Update Statistics */
-        current_memory_allocated += block_size;
-        if (current_memory_allocated > highest_memory_allocated)
-        {
-            highest_memory_allocated = current_memory_allocated;
-        }
-
-        /* Return User Block */
-        return (mem_ptr + sizeof(size_t));
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_free
- *----------------------------------------------------------------------------*/
-void bplib_os_free(void *ptr)
-{
-    if (ptr)
-    {
-        uint8_t *mem_ptr = (uint8_t *)ptr;
-
-        /* Read Amount */
-        size_t *size_ptr   = (size_t *)((uint8_t *)mem_ptr - sizeof(size_t));
-        size_t  block_size = *size_ptr;
-
-        /* Update Statistics */
-        current_memory_allocated -= block_size;
-
-        /* Free Memory Block */
-        free(mem_ptr - sizeof(size_t));
-    }
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_memused - how many bytes of memory currently allocated
- *----------------------------------------------------------------------------*/
-size_t bplib_os_memused(void)
-{
-    return current_memory_allocated;
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_memhigh - the most total bytes in allocation at any given time
- *----------------------------------------------------------------------------*/
-size_t bplib_os_memhigh(void)
-{
-    return highest_memory_allocated;
-}

--- a/os/heap.c
+++ b/os/heap.c
@@ -1,0 +1,48 @@
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
+ *
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/******************************************************************************
+ INCLUDES
+ ******************************************************************************/
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "bplib.h"
+#include "bplib_os.h"
+
+/*----------------------------------------------------------------------------
+ * bplib_os_calloc
+ *----------------------------------------------------------------------------*/
+void *bplib_os_calloc(size_t size)
+{
+    /* Allocate Memory Block */
+    return calloc(size, 1);
+}
+
+/*----------------------------------------------------------------------------
+ * bplib_os_free
+ *----------------------------------------------------------------------------*/
+void bplib_os_free(void *ptr)
+{
+    /* Free Memory Block */
+    free(ptr);
+}

--- a/os/posix.c
+++ b/os/posix.c
@@ -61,9 +61,6 @@ static pthread_mutex_t  lock_of_locks;
 
 static struct timespec prevnow;
 
-static size_t current_memory_allocated = 0;
-static size_t highest_memory_allocated = 0;
-
 static uint32_t flag_log_enable = BP_FLAG_NONCOMPLIANT | BP_FLAG_DROPPED | BP_FLAG_BUNDLE_TOO_LARGE |
                                   BP_FLAG_UNKNOWNREC | BP_FLAG_INVALID_CIPHER_SUITEID |
                                   BP_FLAG_INVALID_BIB_RESULT_TYPE | BP_FLAG_INVALID_BIB_TARGET_TYPE |
@@ -492,71 +489,4 @@ int bplib_os_strnlen(const char *str, int maxlen)
         }
     }
     return maxlen;
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_calloc
- *----------------------------------------------------------------------------*/
-void *bplib_os_calloc(size_t size)
-{
-    /* Allocate Memory Block */
-    size_t   block_size = size + sizeof(size_t);
-    uint8_t *mem_ptr    = (uint8_t *)calloc(block_size, 1);
-    if (mem_ptr)
-    {
-        /* Prepend Amount */
-        size_t *size_ptr = (size_t *)mem_ptr;
-        *size_ptr        = block_size;
-
-        /* Update Statistics */
-        current_memory_allocated += block_size;
-        if (current_memory_allocated > highest_memory_allocated)
-        {
-            highest_memory_allocated = current_memory_allocated;
-        }
-
-        /* Return User Block */
-        return (mem_ptr + sizeof(size_t));
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_free
- *----------------------------------------------------------------------------*/
-void bplib_os_free(void *ptr)
-{
-    if (ptr)
-    {
-        uint8_t *mem_ptr = (uint8_t *)ptr;
-
-        /* Read Amount */
-        size_t *size_ptr   = (size_t *)((uint8_t *)mem_ptr - sizeof(size_t));
-        size_t  block_size = *size_ptr;
-
-        /* Update Statistics */
-        current_memory_allocated -= block_size;
-
-        /* Free Memory Block */
-        free(mem_ptr - sizeof(size_t));
-    }
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_memused - how many bytes of memory currently allocated
- *----------------------------------------------------------------------------*/
-size_t bplib_os_memused(void)
-{
-    return current_memory_allocated;
-}
-
-/*----------------------------------------------------------------------------
- * bplib_os_memhigh - the most total bytes in allocation at any given time
- *----------------------------------------------------------------------------*/
-size_t bplib_os_memhigh(void)
-{
-    return highest_memory_allocated;
 }


### PR DESCRIPTION
Implements a basic integer config/query API that can be used for any runtime or configuration variable.  Initially this is used to replace calls to bplib_os memory functions that reported the memory usage.

This keeps the code layering correct and also adds a stub point for testing other dependent software.