### PR TITLE
Fix #181, add bplib_os submodule to property propagation list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,13 +185,13 @@ endif()
 get_target_property(IS_PIC bplib POSITION_INDEPENDENT_CODE)
 if (IS_PIC)
   set_target_properties(
-    bplib_base bplib_common bplib_mpool bplib_cache bplib_v7
+    bplib_base bplib_common bplib_mpool bplib_cache bplib_v7 bplib_os
     PROPERTIES POSITION_INDEPENDENT_CODE ${IS_PIC}
   )
 endif()
 
 # Set the standard compile options for all submodules (c99, full warnings)
-foreach(TGT bplib bplib_base bplib_common bplib_mpool bplib_cache bplib_v7)
+foreach(TGT bplib bplib_base bplib_common bplib_mpool bplib_cache bplib_v7 bplib_os)
   target_compile_features(${TGT} PRIVATE c_std_99)
   target_compile_options(${TGT} PRIVATE ${BPLIB_COMMON_COMPILE_OPTIONS})
 endforeach()


### PR DESCRIPTION
There are two loops in the top level CMakeLists.txt file that convey certain properties of the main library (bplib) to properties of the submodules so they will be compatible.  The newly-added bplib_os submodule was inadvertly missing from this set, resulting in an unlinkable binary in some configurations.

Fixes #181