### PR TITLE
Fix #190, Correct the typos in bplib coverage tests 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 option(BPLIB_BUILD_TEST_TOOLS "Whether or not to build the test programs as part of BPLib (standalone POSIX builds only)" ${BPLIB_DEFAULT_BUILD_TEST_TOOLS})
 option(BPLIB_INSTALL_LIBRARIES "Whether or not to install the libraries" ${BPLIB_STANDALONE_BUILD_MODE})
 option(BPLIB_USE_EXTERNAL_OSAL "Whether to use an external OSAL package, if OSAL is selected as OS layer" ${BPLIB_STANDALONE_BUILD_MODE})
-option(BPLIB_ENABLE_UNIT_TESTS "Whether to build unit tests (requires NASA OSAL and UT Assert)" ${BPLIB_DEFAULT_BUILD_UNIT_TESTS})
+option(BPLIB_ENABLE_UNIT_TESTS "Whether to build unit tests (requires NASA OSAL and UT Assert)" ${ENABLE_UNIT_TESTS})
 
 set(BPLIB_VERSION_STRING "3.0.99") # development
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 option(BPLIB_BUILD_TEST_TOOLS "Whether or not to build the test programs as part of BPLib (standalone POSIX builds only)" ${BPLIB_DEFAULT_BUILD_TEST_TOOLS})
 option(BPLIB_INSTALL_LIBRARIES "Whether or not to install the libraries" ${BPLIB_STANDALONE_BUILD_MODE})
 option(BPLIB_USE_EXTERNAL_OSAL "Whether to use an external OSAL package, if OSAL is selected as OS layer" ${BPLIB_STANDALONE_BUILD_MODE})
-option(BPLIB_ENABLE_UNIT_TESTS "Whether to build unit tests (requires NASA OSAL and UT Assert)" ${ENABLE_UNIT_TESTS})
+option(BPLIB_ENABLE_UNIT_TESTS "Whether to build unit tests (requires NASA OSAL and UT Assert)" ${BPLIB_DEFAULT_BUILD_UNIT_TESTS})
 
 set(BPLIB_VERSION_STRING "3.0.99") # development
 

--- a/cache/ut-coverage/CMakeLists.txt
+++ b/cache/ut-coverage/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(coverage-bplib_cache-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_cache_testrunner bplib_cache-testrunner)
+add_test(coverage-bplib_cache-testrunner coverage-bplib_cache-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)

--- a/common/ut-coverage/CMakeLists.txt
+++ b/common/ut-coverage/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(coverage-bplib_common-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_common_testrunner bplib_common-testrunner)
+add_test(coverage-bplib_common-testrunner coverage-bplib_common-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)

--- a/lib/ut-coverage/CMakeLists.txt
+++ b/lib/ut-coverage/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(coverage-bplib_base-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_base_testrunner bplib_base-testrunner)
+add_test(coverage-bplib_base-testrunner coverage-bplib_base-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)

--- a/mpool/ut-coverage/CMakeLists.txt
+++ b/mpool/ut-coverage/CMakeLists.txt
@@ -55,7 +55,7 @@ target_link_libraries(coverage-bplib_mpool-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_mpool_testrunner bplib_mpool-testrunner)
+add_test(coverage-bplib_mpool-testrunner coverage-bplib_mpool-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)

--- a/os/ut-coverage/CMakeLists.txt
+++ b/os/ut-coverage/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(coverage-bplib_os-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_os_testrunner bplib_os-testrunner)
+add_test(coverage-bplib_os-testrunner coverage-bplib_os-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)

--- a/v7/ut-coverage/CMakeLists.txt
+++ b/v7/ut-coverage/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(coverage-bplib_v7-testrunner PUBLIC
     ut_assert
 )
 
-add_test(coverage-bplib_v7_testrunner bplib_v7-testrunner)
+add_test(coverage-bplib_v7-testrunner coverage-bplib_v7-testrunner)
 
 # Install the executables to a staging area for test in cross environments
 if (INSTALL_TARGET_LIST)


### PR DESCRIPTION
Describe the contribution
Correct the typos in add_test() function in CMakeLists.txt for all six modules in bplib under ut-coverage directory.

Fixes https://github.com/nasa/bplib/issues/190

Testing performed
Build and run software
re-run "make", "make test". and "make lcov", all six coverage tests have been created.

Expected behavior changes
None

System(s) tested on
CentOS 7

Contributor Info - All information REQUIRED for consideration of pull request
George Lan, MCSG Technologies