### PR TITLE
Fix #201, compiler errors with full optimization

### DIFF
--- a/app/bpcat.c
+++ b/app/bpcat.c
@@ -108,9 +108,13 @@ bp_handle_t storage_intf_id;
 static void app_quick_exit(int signo)
 {
     static const char message[] = "Caught CTRL+C\n";
+    ssize_t           sz;
 
     signal(signo, SIG_DFL);
-    write(STDERR_FILENO, message, sizeof(message) - 1);
+
+    /* squench warning about unused result - no recourse on failure to write to STDERR */
+    sz = write(STDERR_FILENO, message, sizeof(message) - 1);
+    (void)sz;
     app_running = 0;
 }
 
@@ -689,6 +693,7 @@ static void *app_out_entry(void *arg)
 
     desc                = arg;
     curr_bp_buffer      = NULL;
+    curr_app_buffer     = NULL;
     curr_stream_pos     = 0;
     total_message_count = 0;
     segment_remain      = 0;

--- a/mpool/src/v7_mpool.c
+++ b/mpool/src/v7_mpool.c
@@ -825,6 +825,8 @@ bplib_mpool_block_t *bplib_mpool_search_list(const bplib_mpool_block_t *list, bp
     int                     status;
     bplib_mpool_list_iter_t iter;
 
+    memset(&iter, 0, sizeof(iter));
+
     status = bplib_mpool_list_iter_goto_first(list, &iter);
     while (status == BP_SUCCESS)
     {


### PR DESCRIPTION
**Describe the contribution**
Resolves some minor compilation errors when using full optimzations in recent GCC (e.g. -O3)

Fixes #201

**Testing performed**
Build and run with `CMAKE_BUILD_TYPE` set to `Release`, which in turn enables `-O3`

**Expected behavior changes**
Build is successful.  Behavior is the same.

**System(s) tested on**
Ubuntu 22.04, GCC 11.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
