### PR TITLE
Fix #212, correct argument names in prototypes

### DIFF
--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -474,10 +474,10 @@ bplib_mpool_block_t *bplib_mpool_generic_data_uncast(void *blk, bplib_mpool_bloc
  * For a CBOR block this is the length of the CBOR data within this block.  For a user
  * data block, this refers to the size of the actual user object stored here.
  *
- * @param ceb
+ * @param cb pointer to block
  * @return size_t
  */
-size_t bplib_mpool_get_user_content_size(const bplib_mpool_block_t *ceb);
+size_t bplib_mpool_get_user_content_size(const bplib_mpool_block_t *cb);
 
 /**
  * @brief Reads the reference count of the object

--- a/mpool/inc/v7_mpool_bblocks.h
+++ b/mpool/inc/v7_mpool_bblocks.h
@@ -231,7 +231,7 @@ void bplib_mpool_bblock_cbor_append(bplib_mpool_block_t *head, bplib_mpool_block
  * @param cpb
  * @param ccb
  */
-void bplib_mpool_bblock_primary_append(bplib_mpool_bblock_primary_t *cpb, bplib_mpool_block_t *ccb);
+void bplib_mpool_bblock_primary_append(bplib_mpool_bblock_primary_t *cpb, bplib_mpool_block_t *blk);
 
 /**
  * @brief Find a canonical block within the bundle

--- a/mpool/inc/v7_mpstream.h
+++ b/mpool/inc/v7_mpstream.h
@@ -49,7 +49,7 @@ typedef struct bplib_mpool_stream
 void   bplib_mpool_start_stream_init(bplib_mpool_stream_t *mps, bplib_mpool_t *pool, bplib_mpool_stream_dir_t dir);
 size_t bplib_mpool_stream_write(bplib_mpool_stream_t *mps, const void *data, size_t size);
 size_t bplib_mpool_stream_read(bplib_mpool_stream_t *mps, void *data, size_t size);
-size_t bplib_mpool_stream_seek(bplib_mpool_stream_t *mps, size_t position);
+size_t bplib_mpool_stream_seek(bplib_mpool_stream_t *mps, size_t target_position);
 void   bplib_mpool_stream_attach(bplib_mpool_stream_t *mps, bplib_mpool_block_t *head);
 static inline size_t bplib_mpool_stream_tell(const bplib_mpool_stream_t *mps)
 {


### PR DESCRIPTION
**Describe the contribution**
Resolves cppcheck warnings about different argument names in definition vs declaration.

Fixes #212

**Testing performed**
Execute Cppcheck

**Expected behavior changes**
Static Analysis runs cleanly, no functional change

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
