### PR TITLE
Fix #214, resolve build error with CFS and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,5 +209,10 @@ target_include_directories(bplib PUBLIC
 
 if (BPLIB_ENABLE_UNIT_TESTS)
   add_subdirectory(ut-stubs)
-  add_subdirectory(ut-functional)
+
+  # BPLib Sanity checks are only for standalone builds, sanity checks
+  # for CFE/CFS builds should be part of the BP app, as opposed to BPLib
+  if (NOT IS_CFS_ARCH_BUILD)
+    add_subdirectory(ut-functional)
+  endif (NOT IS_CFS_ARCH_BUILD)
 endif (BPLIB_ENABLE_UNIT_TESTS)


### PR DESCRIPTION
**Describe the contribution**
Do not build the sanity checks when part of a CFS build, as this does not link properly due to the different linking environment.  The sanity checks only work in a standalone bplib build.

Fixes #214

**Testing performed**
Build in CFS

**Expected behavior changes**
Build now succeeds

**System(s) tested on**
Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
