### PR TITLE
Fix #217, add handler for bplib_os_get_dtntime_ms

### DIFF
--- a/os/ut-stubs/CMakeLists.txt
+++ b/os/ut-stubs/CMakeLists.txt
@@ -7,7 +7,8 @@
 ##################################################################
 
 add_library(bplib_os_stubs STATIC
-    bplib_os_stubs.c
+  bplib_os_handlers.c
+  bplib_os_stubs.c
 )
 
 target_include_directories(bplib_os_stubs PUBLIC

--- a/os/ut-stubs/bplib_os_handlers.c
+++ b/os/ut-stubs/bplib_os_handlers.c
@@ -1,0 +1,47 @@
+/*
+ * NASA Docket No. GSC-18,587-1 and identified as “The Bundle Protocol Core Flight
+ * System Application (BP) v6.5”
+ *
+ * Copyright © 2020 United States Government as represented by the Administrator of
+ * the National Aeronautics and Space Administration. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @file
+ *
+ * Handler companions for generated BPLib OS stubs
+ */
+
+/* UT includes */
+#include "uttest.h"
+#include "utstubs.h"
+#include "utgenstub.h"
+
+/*----------------------------------------------------------------
+ *
+ * This just translates the 32-bit return status into a 64-bit
+ *
+ *-----------------------------------------------------------------*/
+void UT_DefaultHandler_bplib_os_get_dtntime_ms(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    int32    StatusCode;
+    uint64_t Result;
+
+    UT_Stub_GetInt32StatusCode(Context, &StatusCode);
+
+    Result = StatusCode;
+
+    UT_Stub_SetReturnValue(FuncKey, Result);
+}

--- a/os/ut-stubs/bplib_os_stubs.c
+++ b/os/ut-stubs/bplib_os_stubs.c
@@ -29,6 +29,8 @@
 #include "bplib_os.h"
 #include "utgenstub.h"
 
+void UT_DefaultHandler_bplib_os_get_dtntime_ms(void *, UT_EntryKey_t, const UT_StubContext_t *);
+
 /*
  * ----------------------------------------------------
  * Generated stub function for bplib_os_broadcast_signal()
@@ -128,7 +130,7 @@ uint64_t bplib_os_get_dtntime_ms(void)
 {
     UT_GenStub_SetupReturnBuffer(bplib_os_get_dtntime_ms, uint64_t);
 
-    UT_GenStub_Execute(bplib_os_get_dtntime_ms, Basic, NULL);
+    UT_GenStub_Execute(bplib_os_get_dtntime_ms, Basic, UT_DefaultHandler_bplib_os_get_dtntime_ms);
 
     return UT_GenStub_GetReturnValue(bplib_os_get_dtntime_ms, uint64_t);
 }


### PR DESCRIPTION
**Describe the contribution**
Implements a simple handler to translate the 32-bit return value into 64 bits.  Of course this reduces the possible range, but should be good enough for the vast majority of coverage testing.

Fixes #217

**Testing performed**
Build and run all tests (including new/unmerged mpool test cases)

**Expected behavior changes**
The stub for `bplib_os_get_dtntime_ms()` does not throw an error when used in default configuration.

**System(s) tested on**
Ubuntu

**Additional context**
This only matters for test cases that need to call this stub function.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
