### PR TITLE
Fix #229, correct cast alignment warnings

### DIFF
--- a/cache/src/v7_cache_internal.h
+++ b/cache/src/v7_cache_internal.h
@@ -185,7 +185,7 @@ static inline bplib_mpool_flow_t *bplib_cache_get_flow(bplib_cache_state_t *stat
     bplib_cache_entry_get_container(ptr, offsetof(bplib_cache_entry_t, member))
 static inline bplib_cache_entry_t *bplib_cache_entry_get_container(const bplib_rbt_link_t *link, size_t offset)
 {
-    return (bplib_cache_entry_t *)((uint8_t *)link - offset);
+    return (bplib_cache_entry_t *)(void *)((uint8_t *)link - offset);
 }
 
 void bplib_cache_custody_finalize_dacs(bplib_cache_state_t *state, bplib_cache_entry_t *store_entry);

--- a/lib/src/v7_routing.c
+++ b/lib/src/v7_routing.c
@@ -337,7 +337,7 @@ int bplib_route_register_handler_impl(bplib_routetbl_t *tbl, bp_handle_t intf_id
 
     base_ptr = (uint8_t *)ifp;
 
-    subq = (bplib_mpool_subq_workitem_t *)(base_ptr + func_position);
+    subq = (bplib_mpool_subq_workitem_t *)(void *)(base_ptr + func_position);
 
     if (subq->job_header.handler == new_func)
     {

--- a/mpool/inc/v7_mpool.h
+++ b/mpool/inc/v7_mpool.h
@@ -256,7 +256,7 @@ static inline bool bplib_mpool_is_indirect_block(const bplib_mpool_block_t *cb)
  */
 static inline bool bplib_mpool_is_any_content_node(const bplib_mpool_block_t *cb)
 {
-    return (cb->type >= bplib_mpool_blocktype_generic && cb->type < bplib_mpool_blocktype_max);
+    return (cb->type > bplib_mpool_blocktype_undefined && cb->type < bplib_mpool_blocktype_max);
 }
 
 /**

--- a/mpool/src/v7_mpool_ref.c
+++ b/mpool/src/v7_mpool_ref.c
@@ -98,7 +98,8 @@ bplib_mpool_block_t *bplib_mpool_ref_make_block(bplib_mpool_ref_t refptr, uint32
     pool = bplib_mpool_get_parent_pool_from_link(&bblk->header.base_link);
 
     lock = bplib_mpool_lock_resource(pool);
-    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg, BPLIB_MPOOL_ALLOC_PRI_MHI);
+    rblk = bplib_mpool_alloc_block_internal(pool, bplib_mpool_blocktype_ref, magic_number, init_arg,
+                                            BPLIB_MPOOL_ALLOC_PRI_MHI);
     bplib_mpool_lock_release(lock);
 
     if (rblk == NULL)
@@ -125,7 +126,7 @@ bplib_mpool_ref_t bplib_mpool_ref_from_block(bplib_mpool_block_t *rblk)
         return NULL;
     }
 
-    content = (bplib_mpool_block_content_t *)rblk;
+    content = bplib_mpool_get_block_content(rblk);
 
     return bplib_mpool_ref_duplicate(content->u.ref.pref_target);
 }


### PR DESCRIPTION
**Describe the contribution**
Most of these are fixable by adding an intermediate "void *" cast.

For the case of casting to the "bplib_mpool_block_content_t" type, which occurs somewhat frequently in the mpool logic, use the cast function to do this conversion.  This reduces the number of times this complexity occurs in the source.

Changing this exposed another issue with the check for "bplib_mpool_is_any_content_node()", in that it did not include all the block types for which this is valid - api was not included.  This is also corrected here.

Fixes #229

**Testing performed**
Build and run all tests

**Expected behavior changes**
No major impact - except a minor tweak to the `bplib_mpool_is_any_content_node()` call such that API nodes will now return true.

**System(s) tested on**
Debian Bookworm

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
