### PR TITLE
Fix #236, correct uninitialized variable warnings

### DIFF
--- a/cache/ut-coverage/test_bplib_cache_setup.c
+++ b/cache/ut-coverage/test_bplib_cache_setup.c
@@ -27,6 +27,8 @@ void test_setup_cache_state(bplib_mpool_block_t *sblk)
 {
     bplib_mpool_list_iter_t list_it;
     bplib_mpool_block_t     pending_list;
+
+    bplib_mpool_init_list_head(NULL, &pending_list);
     bplib_mpool_list_iter_goto_first(&pending_list, &list_it);
 }
 

--- a/cache/ut-coverage/test_v7_cache_custody.c
+++ b/cache/ut-coverage/test_v7_cache_custody.c
@@ -160,15 +160,15 @@ void test_bplib_cache_custody_find_dacs_match(void)
     /* Test function for:
      * int bplib_cache_custody_find_dacs_match(const bplib_rbt_link_t *node, void *arg)
      */
-    bplib_rbt_link_t             node;
     bplib_cache_custodian_info_t custody_info;
-    bplib_cache_entry_t         *store_entry = bplib_cache_entry_from_link(&node, hash_rbt_link);
+    bplib_cache_entry_t          store_entry;
 
-    memset(&node, 0, sizeof(bplib_rbt_link_t));
     memset(&custody_info, 0, sizeof(bplib_cache_custodian_info_t));
-    store_entry->state = bplib_cache_entry_state_generate_dacs;
+    memset(&store_entry, 0, sizeof(bplib_cache_entry_t));
 
-    UtAssert_UINT32_EQ(bplib_cache_custody_find_dacs_match(&node, &custody_info), 0);
+    store_entry.state = bplib_cache_entry_state_generate_dacs;
+
+    UtAssert_UINT32_EQ(bplib_cache_custody_find_dacs_match(&store_entry.hash_rbt_link, &custody_info), 0);
 }
 
 void test_bplib_cache_custody_find_pending_dacs(void)

--- a/v7/ut-coverage/test_v7_bp_bitmap.c
+++ b/v7/ut-coverage/test_v7_bp_bitmap.c
@@ -27,7 +27,7 @@ void test_v7_encode_bitmap(void)
      * void v7_encode_bitmap(v7_encode_state_t *enc, const uint8_t *v, const v7_bitmap_table_t *ptbl)
      */
     v7_encode_state_t enc;
-    uint8_t           v[5];
+    uint8_t           v[5] = { 1, 0, 1, 0, 1 };
     v7_bitmap_table_t ptbl[2] = {{0}, {0}};
 
     memset(&enc, 0, sizeof(v7_decode_state_t));


### PR DESCRIPTION
**Describe the contribution**
Corrects the initialization for 3 unit test cases

Fixes #236

**Testing performed**
Build and run tests

**Expected behavior changes**
Now builds cleanly, no warnings

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
