### PR TITLE
Fix #248, change blocktype value used for custody

### DIFF
--- a/v7/inc/v7_types.h
+++ b/v7/inc/v7_types.h
@@ -59,8 +59,7 @@ typedef enum bp_blocktype
     bp_blocktype_hopCount                    = 10,
     bp_blocktype_bpsec_bib                   = 11,
     bp_blocktype_bpsec_bcb                   = 12,
-    bp_blocktype_custodyTrackingBlock        = 13,
-    bp_blocktype_MAX_NORMAL                  = 14,
+    bp_blocktype_custodyTrackingBlock        = 73,
 
     /*
      * These are internal block types - they exist only locally in this implementation

--- a/v7/src/v7_bp_canonical_block.c
+++ b/v7/src/v7_bp_canonical_block.c
@@ -69,7 +69,7 @@ void v7_encode_bp_canonical_bundle_block(v7_encode_state_t *enc, const bp_canoni
             break;
     }
 
-    if (encode_blocktype < bp_blocktype_MAX_NORMAL)
+    if (encode_blocktype < bp_blocktype_SPECIAL_BLOCKS_START)
     {
         v7_encode_bp_blocktype(enc, &encode_blocktype);
         v7_encode_bp_blocknum(enc, &v->blockNum);


### PR DESCRIPTION
**Describe the contribution**
Change the custody signal blocktype from 13 to 73

Fixes #248

**Testing performed**
Interoperability testing with remote node using different BP software

**Expected behavior changes**
Will not conflict with custom blocktype used by remote software

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
