### PR TITLE
Fix #246, recognize dtn:none special endpoint ID

### DIFF
--- a/v7/inc/v7_types.h
+++ b/v7/inc/v7_types.h
@@ -91,12 +91,14 @@ typedef bp_integer_t bp_sequencenumber_t;
 typedef enum bp_iana_uri_scheme
 {
     bp_iana_uri_scheme_undefined = 0,
+    bp_iana_uri_scheme_dtn       = 1,
     bp_iana_uri_scheme_ipn       = 2
 } bp_iana_uri_scheme_t;
 
 typedef enum bp_endpointid_scheme
 {
     bp_endpointid_scheme_undefined = 0,
+    bp_endpointid_scheme_dtn       = 1,
     bp_endpointid_scheme_ipn       = 2
 } bp_endpointid_scheme_t;
 
@@ -108,6 +110,11 @@ typedef struct bp_ipn_uri_ssp
     bp_ipn_nodenumber_t    node_number;
     bp_ipn_servicenumber_t service_number;
 } bp_ipn_uri_ssp_t;
+
+typedef struct bp_dtn_uri_ssp
+{
+    bool is_none; /**< indicates the special address "dtn:none" per RFC9171 section 4.2.5.1.1 */
+} bp_dtn_uri_ssp_t;
 
 typedef struct bp_creation_timestamp
 {
@@ -194,6 +201,7 @@ typedef bp_integer_t bp_adu_length_t;
 
 typedef union bp_endpointid_ssp
 {
+    bp_dtn_uri_ssp_t dtn; /* present if scheme == bp_endpointid_scheme_dtn */
     bp_ipn_uri_ssp_t ipn; /* present if scheme == bp_endpointid_scheme_ipn */
 } bp_endpointid_ssp_t;
 


### PR DESCRIPTION
**Describe the contribution**
This uses the DTN encoding scheme as opposed to IPN, but has a single integer value of 0 as the SSP.  This construct should be recognized by the codec routines.

Fixes #246

**Testing performed**
This PR includes a sample CBOR-encoded bundle using dtn:none as part of sanity test

**Expected behavior changes**
Correctly recognizes and decodes this endpoint ID.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
