### PR TITLE
Fix #245, implement safer codec loops

### DIFF
--- a/v7/src/v7_bp_container.c
+++ b/v7/src/v7_bp_container.c
@@ -101,15 +101,16 @@ void v7_decode_container(v7_decode_state_t *dec, size_t entries, v7_decode_func_
                 func(dec, arg);
 
                 /* This should have consumed every item */
-                if (!cbor_value_at_end(&content))
+                if (!dec->error)
                 {
-                    dec->error = true;
-                }
-
-                /* return to parent scope */
-                if (cbor_value_leave_container(parent, &content) != CborNoError)
-                {
-                    dec->error = true;
+                    if (!cbor_value_at_end(&content))
+                    {
+                        dec->error = true;
+                    }
+                    else if (cbor_value_leave_container(parent, &content) != CborNoError)
+                    {
+                        dec->error = true;
+                    }
                 }
 
                 dec->cbor = parent;

--- a/v7/src/v7_bp_endpointid.c
+++ b/v7/src/v7_bp_endpointid.c
@@ -25,6 +25,13 @@
 #include "v7_encode_internal.h"
 #include "v7_decode_internal.h"
 
+typedef enum bp_ipn_ssp_field
+{
+    bp_ipn_ssp_field_undef,
+    bp_ipn_ssp_field_nodenumber,
+    bp_ipn_ssp_field_servicenumber,
+    bp_ipn_ssp_field_done
+} bp_ipn_ssp_field_t;
 /*
  * -----------------------------------------------------------------------------------
  * IMPLEMENTATION
@@ -49,10 +56,25 @@ void v7_encode_bp_ipn_servicenumber(v7_encode_state_t *enc, const bp_ipn_service
 
 void v7_encode_bp_ipn_uri_ssp_impl(v7_encode_state_t *enc, const void *arg)
 {
-    const bp_ipn_uri_ssp_t *v = arg;
+    const bp_ipn_uri_ssp_t *v        = arg;
+    bp_ipn_ssp_field_t      field_id = bp_ipn_ssp_field_undef;
 
-    v7_encode_bp_ipn_nodenumber(enc, &v->node_number);
-    v7_encode_bp_ipn_servicenumber(enc, &v->service_number);
+    while (field_id < bp_ipn_ssp_field_done && !enc->error)
+    {
+        switch (field_id)
+        {
+            case bp_ipn_ssp_field_nodenumber:
+                v7_encode_bp_ipn_nodenumber(enc, &v->node_number);
+                break;
+            case bp_ipn_ssp_field_servicenumber:
+                v7_encode_bp_ipn_servicenumber(enc, &v->service_number);
+                break;
+            default:
+                break;
+        }
+
+        ++field_id;
+    }
 }
 
 void v7_encode_bp_ipn_uri_ssp(v7_encode_state_t *enc, const bp_ipn_uri_ssp_t *v)
@@ -101,10 +123,25 @@ void v7_decode_bp_ipn_servicenumber(v7_decode_state_t *dec, bp_ipn_servicenumber
 
 void v7_decode_bp_ipn_uri_ssp_impl(v7_decode_state_t *dec, void *arg)
 {
-    bp_ipn_uri_ssp_t *v = arg;
+    bp_ipn_uri_ssp_t  *v        = arg;
+    bp_ipn_ssp_field_t field_id = bp_ipn_ssp_field_undef;
 
-    v7_decode_bp_ipn_nodenumber(dec, &v->node_number);
-    v7_decode_bp_ipn_servicenumber(dec, &v->service_number);
+    while (field_id < bp_ipn_ssp_field_done && !dec->error && !cbor_value_at_end(dec->cbor))
+    {
+        switch (field_id)
+        {
+            case bp_ipn_ssp_field_nodenumber:
+                v7_decode_bp_ipn_nodenumber(dec, &v->node_number);
+                break;
+            case bp_ipn_ssp_field_servicenumber:
+                v7_decode_bp_ipn_servicenumber(dec, &v->service_number);
+                break;
+            default:
+                break;
+        }
+
+        ++field_id;
+    }
 }
 
 void v7_decode_bp_ipn_uri_ssp(v7_decode_state_t *dec, bp_ipn_uri_ssp_t *v)


### PR DESCRIPTION
**Describe the contribution**
Implement the encoding and decoding of CBOR containers as a loop.  This permits the "error" flag to be easily polled after each iteration, and if it is ever set, the operation should exit safely.

This is important because after any encode/decode issue, the tiny CBOR state will no longer be in sync with the data, and this library may assert if invoked with a bad state object.

Fixes #245

**Testing performed**
Pass in unrecognized/non-conformant bundle and confirm decoding stops - no additional calls into TinyCBOR are made.

**Expected behavior changes**
No change of assertion inside TinyCBOR if called after codec state becomes invalid

**System(s) tested on**
Debian + TinyCBOR v0.60

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
