### PR TITLE
DTNN-330-Replace TinyCBOR APIs with QCBOR APIs-Draft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if (IS_CFS_ARCH_BUILD)
   # The CFE build system determines whether to create a shared or static object inside this routine
   add_cfe_app(bplib ${BPLIB_SRC})
 
-  target_link_libraries(bplib ${TINYCBOR_LDFLAGS})
+  target_link_libraries(bplib ${TINYCBOR_LDFLAGS} ${QCBOR_LDFLAGS})
 
 else()
 
@@ -133,7 +133,7 @@ else()
   add_library(bplib ${BPLIB_SRC})
 
   # link with the requisite dependencies
-  target_link_libraries(bplib ${TINYCBOR_LDFLAGS})
+  target_link_libraries(bplib ${TINYCBOR_LDFLAGS} ${QCBOR_LDFLAGS})
 
   # Add in the required link libraries based on OS adapter selection
   # this should preferably be in OS subdirectory, but it needs to be done

--- a/v7/CMakeLists.txt
+++ b/v7/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(PkgConfig)
 pkg_search_module(TINYCBOR tinycbor REQUIRED)
 message(STATUS "Found tinycbor version ${TINYCBOR_VERSION}")
 
+find_package(PkgConfig)
+pkg_search_module(QCBOR qcbor REQUIRED)
+message(STATUS "Found qcbor version ${QCBOR_VERSION}")
+
 add_library(bplib_v7 OBJECT
     src/v7_codec_common.c
     src/v7_encode_api.c
@@ -37,6 +41,7 @@ target_include_directories(bplib_v7 PRIVATE
     # nothing outside of here should directly call TinyCBOR, so this
     # can be considered private to this submodule
     ${TINYCBOR_INCLUDE_DIRS}
+    ${QCBOR_INCLUDE_DIRS}
     $<TARGET_PROPERTY:bplib_common,INTERFACE_INCLUDE_DIRECTORIES>
 )
 

--- a/v7/src/v7_bp_basetypes.c
+++ b/v7/src/v7_bp_basetypes.c
@@ -36,10 +36,7 @@ void v7_encode_small_int(v7_encode_state_t *enc, int val)
 {
     if (!enc->error)
     {
-        if (cbor_encode_int(enc->cbor, val) != CborNoError)
-        {
-            enc->error = true;
-        }
+        QCBOREncode_AddInt64(enc->cbor, val);
     }
 }
 
@@ -48,22 +45,14 @@ int v7_decode_small_int(v7_decode_state_t *dec)
     int val;
 
     val = 0;
+            
     if (!dec->error)
     {
-        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborIntegerType)
+        QCBORDecode_GetInt64(dec->cbor, (int64_t*)&val);
+        QCBORError err = QCBORDecode_GetError(dec->cbor);
+        if(err != QCBOR_SUCCESS)
         {
             dec->error = true;
-        }
-        else
-        {
-            if (cbor_value_get_int(dec->cbor, &val) != CborNoError)
-            {
-                dec->error = true;
-            }
-            else if (cbor_value_advance_fixed(dec->cbor) != CborNoError)
-            {
-                dec->error = true;
-            }
         }
     }
 
@@ -83,20 +72,11 @@ void v7_decode_bp_integer(v7_decode_state_t *dec, bp_integer_t *v)
     val = 0;
     if (!dec->error)
     {
-        if (cbor_value_at_end(dec->cbor) || cbor_value_get_type(dec->cbor) != CborIntegerType)
+        QCBORDecode_GetUInt64(dec->cbor, &val);
+        QCBORError err = QCBORDecode_GetError(dec->cbor);
+        if(err != QCBOR_SUCCESS)
         {
             dec->error = true;
-        }
-        else
-        {
-            if (cbor_value_get_uint64(dec->cbor, &val) != CborNoError)
-            {
-                dec->error = true;
-            }
-            else if (cbor_value_advance_fixed(dec->cbor) != CborNoError)
-            {
-                dec->error = true;
-            }
         }
     }
 
@@ -107,10 +87,7 @@ void v7_encode_bp_integer(v7_encode_state_t *enc, const bp_integer_t *v)
 {
     if (!enc->error)
     {
-        if (cbor_encode_uint(enc->cbor, *v) != CborNoError)
-        {
-            enc->error = true;
-        }
+        QCBOREncode_AddUInt64(enc->cbor, *v);
     }
 }
 

--- a/v7/src/v7_bp_endpointid.c
+++ b/v7/src/v7_bp_endpointid.c
@@ -178,8 +178,8 @@ void v7_decode_bp_ipn_uri_ssp_impl(v7_decode_state_t *dec, void *arg)
 {
     bp_ipn_uri_ssp_t  *v        = arg;
     bp_ipn_ssp_field_t field_id = bp_ipn_ssp_field_undef;
-
-    while (field_id < bp_ipn_ssp_field_done && !dec->error && !cbor_value_at_end(dec->cbor))
+    
+    while (field_id < bp_ipn_ssp_field_done && !dec->error)
     {
         switch (field_id)
         {
@@ -241,8 +241,8 @@ void v7_decode_bp_endpointid_buffer_impl(v7_decode_state_t *dec, void *arg)
 {
     bp_endpointid_buffer_t *v        = arg;
     bp_endpointid_field_t   field_id = bp_endpointid_field_undef;
-
-    while (field_id < bp_endpointid_field_done && !dec->error && !cbor_value_at_end(dec->cbor))
+    
+    while (field_id < bp_endpointid_field_done && !dec->error)
     {
         switch (field_id)
         {

--- a/v7/src/v7_bp_hop_count_block.c
+++ b/v7/src/v7_bp_hop_count_block.c
@@ -72,8 +72,8 @@ void v7_decode_bp_hop_count_block_impl(v7_decode_state_t *dec, void *arg)
 {
     bp_hop_count_block_t *v        = arg;
     bp_hop_count_field_t  field_id = bp_hop_count_field_undef;
-
-    while (field_id < bp_hop_count_field_done && !dec->error && !cbor_value_at_end(dec->cbor))
+    
+    while (field_id < bp_hop_count_field_done)
     {
         switch (field_id)
         {

--- a/v7/src/v7_bp_primary_block.c
+++ b/v7/src/v7_bp_primary_block.c
@@ -223,8 +223,7 @@ void v7_decode_bp_primary_block_impl(v7_decode_state_t *dec, void *arg)
 {
     bp_primary_block_t *v        = arg;
     bp_pri_field_t      field_id = bp_pri_field_undef;
-
-    while (field_id < bp_pri_field_done && !dec->error && !cbor_value_at_end(dec->cbor))
+    while (field_id < bp_pri_field_done && !dec->error)
     {
         switch (field_id)
         {
@@ -295,5 +294,5 @@ void v7_decode_bp_primary_block_impl(v7_decode_state_t *dec, void *arg)
 
 void v7_decode_bp_primary_block(v7_decode_state_t *dec, bp_primary_block_t *v)
 {
-    v7_decode_container(dec, CborIndefiniteLength, v7_decode_bp_primary_block_impl, v);
+    v7_decode_container(dec, QCBOR_MAX_ITEMS_IN_ARRAY, v7_decode_bp_primary_block_impl, v);
 }

--- a/v7/src/v7_codec_common.c
+++ b/v7/src/v7_codec_common.c
@@ -23,7 +23,6 @@
  ******************************************************************************/
 
 #include "v7_codec_internal.h"
-#include "cbor.h"
 
 bplib_crc_parameters_t *v7_codec_get_crc_algorithm(bp_crctype_t crctype)
 {
@@ -142,7 +141,7 @@ size_t v7_copy_full_bundle_out(bplib_mpool_bblock_primary_t *cpb, void *buffer, 
     out_p  = buffer;
     *out_p = 0x9F; /* Start CBOR indefinite-length array */
     ++out_p;
-
+    
     remain_sz = buf_sz - 2;
 
     chunk_sz =

--- a/v7/src/v7_custody_acknowledgement_record.c
+++ b/v7/src/v7_custody_acknowledgement_record.c
@@ -59,8 +59,8 @@ void v7_encode_bp_custody_acknowledement_record(v7_encode_state_t *enc, const bp
 void v7_decode_bp_custody_acceptance_seqlist_impl(v7_decode_state_t *dec, void *arg)
 {
     bp_custody_accept_payload_block_t *v = arg;
-
-    while (!cbor_value_at_end(dec->cbor) && v->num_entries < BP_DACS_MAX_SEQ_PER_PAYLOAD)
+    
+    while (v->num_entries < BP_DACS_MAX_SEQ_PER_PAYLOAD)
     {
         v7_decode_bp_integer(dec, &v->sequence_nums[v->num_entries]);
         if (dec->error)
@@ -77,7 +77,7 @@ void v7_decode_bp_custody_acknowledement_record_impl(v7_decode_state_t *dec, voi
     bp_custody_accept_payload_block_t *v = arg;
 
     v7_decode_bp_endpointid_buffer(dec, &v->flow_source_eid);
-    v7_decode_container(dec, CborIndefiniteLength, v7_decode_bp_custody_acceptance_seqlist_impl, v);
+    v7_decode_container(dec, QCBOR_MAX_ITEMS_IN_ARRAY, v7_decode_bp_custody_acceptance_seqlist_impl, v);
 }
 
 void v7_decode_bp_custody_acknowledement_record(v7_decode_state_t *dec, bp_custody_accept_payload_block_t *v)

--- a/v7/src/v7_decode_internal.h
+++ b/v7/src/v7_decode_internal.h
@@ -26,13 +26,14 @@
  ******************************************************************************/
 
 #include "v7_codec_internal.h"
-#include "cbor.h"
+#include "qcbor.h"
+#include "qcbor_spiffy_decode.h"
 
 typedef struct v7_decode_state
 {
     bool           error;
     const uint8_t *base;
-    CborValue     *cbor;
+    QCBORDecodeContext *cbor;
 } v7_decode_state_t;
 
 typedef struct

--- a/v7/src/v7_encode_internal.h
+++ b/v7/src/v7_encode_internal.h
@@ -26,7 +26,7 @@
  ******************************************************************************/
 
 #include "v7_codec_internal.h"
-#include "cbor.h"
+#include "qcbor.h"
 
 typedef struct v7_encode_state
 {
@@ -36,7 +36,7 @@ typedef struct v7_encode_state
     bp_crcval_t             crc_val;
     bplib_crc_parameters_t *crc_params;
 
-    CborEncoder *cbor;
+    QCBOREncodeContext *cbor;
 
     size_t total_bytes_encoded;
 
@@ -92,7 +92,7 @@ void v7_encode_bp_canonical_block_buffer(v7_encode_state_t *enc, const bp_canoni
 
 int       v7_encoder_mpstream_write(void *arg, const void *ptr, size_t sz);
 int       v7_encoder_write_crc(v7_encode_state_t *enc);
-CborError v7_encoder_write_wrapper(void *arg, const void *ptr, size_t sz, CborEncoderAppendType at);
+int v7_encoder_write_wrapper(void *arg, const void *ptr, size_t sz);
 void      v7_encode_bp_adminrec_payload_impl(v7_encode_state_t *enc, const void *arg);
 void      v7_encode_bp_custody_acceptance_seqlist_impl(v7_encode_state_t *enc, const void *arg);
 void      v7_encode_bp_endpointid_scheme(v7_encode_state_t *enc, const bp_endpointid_scheme_t *v);


### PR DESCRIPTION
**Describe the contribution**
DTNN-330, replace TinyCBOR APIs with QCBOR APIs

**Testing performed**
Steps taken to test the contribution:
1. Build and install QCBOR 
2. Built standalone POSIX version of bplib
3. Run two bpcat servers with different node IDs and local IP. They will send messages through bundle protocol.

**Expected behavior changes**
Replace the TinyCBOR APIs with QCBOR APIs for CBOR encoder and decoder. Behavior should be the same

**System(s) tested on**
 - AWS cloud 

**Additional context**
Add any other context about the contribution here.

**Contributor Info - All information REQUIRED for consideration of pull request**
George Lan
george.lan@nasa.gov
